### PR TITLE
[PR] horizontalEdges에서 offset으로 사용하던 내용을 inset으로 변경

### DIFF
--- a/CoNet/Main/Meeting/MeetingDelPopUpViewController.swift
+++ b/CoNet/Main/Meeting/MeetingDelPopUpViewController.swift
@@ -82,8 +82,7 @@ extension MeetingDelPopUpViewController {
         }
         
         popUp.snp.makeConstraints { make in
-            make.width.equalTo(view.snp.width).offset(-48)
-            make.horizontalEdges.equalTo(view.snp.horizontalEdges).offset(24)
+            make.horizontalEdges.equalTo(view.snp.horizontalEdges).inset(24)
             make.center.equalTo(view.snp.center)
         }
     }

--- a/CoNet/Main/Meeting/MeetingOutPopUpViewController.swift
+++ b/CoNet/Main/Meeting/MeetingOutPopUpViewController.swift
@@ -74,6 +74,7 @@ extension MeetingOutPopUpViewController {
         view.addSubview(background)
         view.addSubview(popUp)
     }
+    
     // 모든 layout Constraints
     private func layoutConstraints() {
         background.snp.makeConstraints { make in

--- a/CoNet/Main/Meeting/MeetingOutPopUpViewController.swift
+++ b/CoNet/Main/Meeting/MeetingOutPopUpViewController.swift
@@ -81,8 +81,7 @@ extension MeetingOutPopUpViewController {
         }
         
         popUp.snp.makeConstraints { make in
-            make.width.equalTo(view.snp.width).offset(-48)
-            make.horizontalEdges.equalTo(view.snp.horizontalEdges).offset(24)
+            make.horizontalEdges.equalTo(view.snp.horizontalEdges).inset(24)
             make.center.equalTo(view.snp.center)
         }
     }

--- a/CoNet/Main/MyPage/InquireViewController.swift
+++ b/CoNet/Main/MyPage/InquireViewController.swift
@@ -135,7 +135,6 @@ extension InquireViewController {
     private func emailButtonConstraints() {
         let safeArea = view.safeAreaLayoutGuide
         
-        
         emailButton.snp.makeConstraints { make in
             make.width.equalTo(140)
             make.height.equalTo(40)
@@ -143,13 +142,11 @@ extension InquireViewController {
             make.leading.equalTo(safeArea.snp.leading).offset(24)
         }
         
-        
         mailImage.snp.makeConstraints { make in
             make.width.height.equalTo(16)
             make.centerY.equalTo(emailButton.snp.centerY)
             make.leading.equalTo(emailButton.snp.leading).offset(20)
         }
-        
         
         emailLabel.snp.makeConstraints { make in
             make.centerY.equalTo(mailImage.snp.centerY)

--- a/CoNet/Main/MyPage/LogoutPopUpViewController.swift
+++ b/CoNet/Main/MyPage/LogoutPopUpViewController.swift
@@ -82,8 +82,7 @@ extension LogoutPopUpViewController {
     // 팝업 Constraints
     private func popUpConstraints() {
         popUp.snp.makeConstraints { make in
-            make.width.equalTo(view.snp.width).offset(-48)
-            make.horizontalEdges.equalTo(view.snp.horizontalEdges).offset(24)
+            make.horizontalEdges.equalTo(view.snp.horizontalEdges).inset(24)
             make.center.equalTo(view.snp.center)
         }
     }

--- a/CoNet/Main/MyPage/MyPageViewController.swift
+++ b/CoNet/Main/MyPage/MyPageViewController.swift
@@ -82,9 +82,9 @@ class MyPageViewController: UIViewController {
     }
     
     // 다음 VC를 보여주는 공통 code
-    private func showViewController(_ vc: UIViewController) {
-        vc.hidesBottomBarWhenPushed = true
-        navigationController?.pushViewController(vc, animated: true)
+    private func showViewController(_ viewController: UIViewController) {
+        viewController.hidesBottomBarWhenPushed = true
+        navigationController?.pushViewController(viewController, animated: true)
     }
     
     @objc func showLogoutPopup(_ sender: UIView) {

--- a/CoNet/Main/MyPage/UserInfo/ChangeNameViewController.swift
+++ b/CoNet/Main/MyPage/UserInfo/ChangeNameViewController.swift
@@ -183,7 +183,7 @@ extension ChangeNameViewController {
         nameLabel.snp.makeConstraints { make in
             make.height.equalTo(18)
             make.top.equalTo(safeArea.snp.top).offset(46)
-            make.horizontalEdges.equalTo(view.snp.horizontalEdges).offset(24)
+            make.horizontalEdges.equalTo(view.snp.horizontalEdges).inset(24)
         }
         
         // 이름 텍스트필드

--- a/CoNet/Main/MyPage/UserInfo/UserInfoViewController.swift
+++ b/CoNet/Main/MyPage/UserInfo/UserInfoViewController.swift
@@ -205,27 +205,26 @@ extension UserInfoViewController {
         nameLabel.snp.makeConstraints { make in
             make.height.equalTo(18)
             make.top.equalTo(profileImage.snp.bottom).offset(30)
-            make.horizontalEdges.equalTo(view.snp.horizontalEdges).offset(24)
+            make.horizontalEdges.equalTo(view.snp.horizontalEdges).inset(24)
         }
         
         changeNameButton.snp.makeConstraints { make in
             make.height.equalTo(24)
-            make.horizontalEdges.equalTo(view.snp.horizontalEdges).offset(24)
+            make.horizontalEdges.equalTo(view.snp.horizontalEdges).inset(24)
             make.top.equalTo(nameLabel.snp.bottom).offset(6)
         }
         
         // 이름 변경 버튼 row
         changeNameView.snp.makeConstraints { make in
             make.height.equalTo(24)
-            make.horizontalEdges.equalTo(view.snp.horizontalEdges).offset(24)
+            make.horizontalEdges.equalTo(view.snp.horizontalEdges).inset(24)
             make.top.equalTo(nameLabel.snp.bottom).offset(6)
         }
         
         // 구분선
         divider.snp.makeConstraints { make in
             make.height.equalTo(1)
-            make.width.equalTo(view.snp.width).offset(-48)
-            make.horizontalEdges.equalTo(view.snp.horizontalEdges).offset(24)
+            make.horizontalEdges.equalTo(view.snp.horizontalEdges).inset(24)
             make.top.equalTo(changeNameView.snp.bottom).offset(16)
         }
     }
@@ -236,14 +235,14 @@ extension UserInfoViewController {
         linkedSocialLabel.snp.makeConstraints { make in
             make.height.equalTo(18)
             make.top.equalTo(divider.snp.bottom).offset(16)
-            make.horizontalEdges.equalTo(view.snp.horizontalEdges).offset(24)
+            make.horizontalEdges.equalTo(view.snp.horizontalEdges).inset(24)
         }
         
         // 연결된 계정 - 카카오/애플
         emailLabel.snp.makeConstraints { make in
             make.height.equalTo(22)
             make.top.equalTo(linkedSocialLabel.snp.bottom).offset(8)
-            make.horizontalEdges.equalTo(view.snp.horizontalEdges).offset(24)
+            make.horizontalEdges.equalTo(view.snp.horizontalEdges).inset(24)
         }
         
         // 카카오/애플 아이콘


### PR DESCRIPTION
<!-- PR 제목은
      [PR] 어떤 내용입니다!
      로 해주세요~!! -->

## PR Type ⚙️
<!-- 어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크 후 남겨줍니다.
      사용하지 않는 리스트는 삭제해주세요! -->
      
- [x] Fix: 버그 수정
- [x] Style: 코드 포맷 변경, 세미 콜론 누락, 코드 수정이 없는 경우

<br>


## What is this PR? 📝

### Related Issue Number
<!-- 연관된 이슈 번호를 모두 작성해 주세요. ex, #23, #24 -->
- #56 
<br>

### Changes
<!-- PR의 작업 내용에 대한 설명을 적습니다. - 추가/변경사항에 대해 작성해주세요. -->
- horizontalEdges에서 offset으로 사용하던 내용을 inset으로 변경
- 과 더불어 린트를 없애기 위한 작은 수정이 함께 있습니다!
<br>

### ScreenShots
<!--
뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
적절한 사이즈로 첨부하는 코드 👇
<img width="300" alt="" src="이미지URL">
-->
화면이 여러개라 스크린샷은 별도로 첨부하지 않겠습니다!
마이페이지, 마이페이지 > 회원정보, 마이페이지 > 회원정보 > 이름변경, 마이페이지 > 로그아웃
모임 나가기, 모임 삭제하기
페이지가 수정되었습니다.
<br>


## Other information 🔥
<!-- 기타 참고사항이 있다면 작성해줍니다. -->
- 마이페이지에서 이름 변경으로 넘어가는 row 오른쪽 끝에 화살표가 사라진 버그를 수정했어요!
- 이게 이유인줄 몰랐는데.. 이걸로 해결!! 와우 !!!!
<br>



