### PR TITLE
[PR] 로그인 화면 리팩토링(인데 카카오톡 앱 로그인 오류 수정도 있음)

### DIFF
--- a/CoNet.xcodeproj/project.pbxproj
+++ b/CoNet.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		51DA64962A532CB300BBA4C0 /* KakaoSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 51DA64952A532CB300BBA4C0 /* KakaoSDK */; };
 		51DA64992A532CF800BBA4C0 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 51DA64982A532CF800BBA4C0 /* SnapKit */; };
 		51E8242B2B62AEEA00A56F3A /* KakaoLoginButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E8242A2B62AEEA00A56F3A /* KakaoLoginButton.swift */; };
+		51E8242D2B62B70700A56F3A /* AppleLoginButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E8242C2B62B70700A56F3A /* AppleLoginButton.swift */; };
 		51F2A4682A54804100D134CC /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F2A4672A54804100D134CC /* ColorExtension.swift */; };
 		51F2A46A2A548A1000D134CC /* FontExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F2A4692A548A1000D134CC /* FontExtension.swift */; };
 		51F2A46D2A54960200D134CC /* KeychainSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 51F2A46C2A54960200D134CC /* KeychainSwift */; };
@@ -204,6 +205,7 @@
 		51B526CB2A6C3988009DBFB4 /* DecidedPlanCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecidedPlanCell.swift; sourceTree = "<group>"; };
 		51C29AF22B31DD7600B1A1BA /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		51E8242A2B62AEEA00A56F3A /* KakaoLoginButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLoginButton.swift; sourceTree = "<group>"; };
+		51E8242C2B62B70700A56F3A /* AppleLoginButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginButton.swift; sourceTree = "<group>"; };
 		51F2A4672A54804100D134CC /* ColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorExtension.swift; sourceTree = "<group>"; };
 		51F2A4692A548A1000D134CC /* FontExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontExtension.swift; sourceTree = "<group>"; };
 		51F2A4702A5497A500D134CC /* AuthAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthAPI.swift; sourceTree = "<group>"; };
@@ -566,6 +568,7 @@
 			children = (
 				1AE23DBA2A59837F000D498F /* LoginViewController.swift */,
 				51E8242A2B62AEEA00A56F3A /* KakaoLoginButton.swift */,
+				51E8242C2B62B70700A56F3A /* AppleLoginButton.swift */,
 			);
 			path = Login;
 			sourceTree = "<group>";
@@ -735,6 +738,7 @@
 				1AA197BB2A73C54B001064F8 /* PlanMemberBottonSheetViewController.swift in Sources */,
 				1ABF8C882A694B3800023A8D /* MeetingInfoEditViewController.swift in Sources */,
 				513D6B892A4BFCCC00E9ACDA /* AppDelegate.swift in Sources */,
+				51E8242D2B62B70700A56F3A /* AppleLoginButton.swift in Sources */,
 				1A3AD0132A6958B400975427 /* InvitationCodeViewController.swift in Sources */,
 				515E53BF2A77D16D00536C6D /* Meeting.swift in Sources */,
 				512675912A83D71600AFC46C /* EditMemberCollectionViewCell.swift in Sources */,

--- a/CoNet.xcodeproj/project.pbxproj
+++ b/CoNet.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		51B526CC2A6C3988009DBFB4 /* DecidedPlanCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B526CB2A6C3988009DBFB4 /* DecidedPlanCell.swift */; };
 		51DA64962A532CB300BBA4C0 /* KakaoSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 51DA64952A532CB300BBA4C0 /* KakaoSDK */; };
 		51DA64992A532CF800BBA4C0 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 51DA64982A532CF800BBA4C0 /* SnapKit */; };
+		51E8242B2B62AEEA00A56F3A /* KakaoLoginButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E8242A2B62AEEA00A56F3A /* KakaoLoginButton.swift */; };
 		51F2A4682A54804100D134CC /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F2A4672A54804100D134CC /* ColorExtension.swift */; };
 		51F2A46A2A548A1000D134CC /* FontExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F2A4692A548A1000D134CC /* FontExtension.swift */; };
 		51F2A46D2A54960200D134CC /* KeychainSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 51F2A46C2A54960200D134CC /* KeychainSwift */; };
@@ -202,6 +203,7 @@
 		51B526C92A6C3901009DBFB4 /* DecidedPlanListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecidedPlanListViewController.swift; sourceTree = "<group>"; };
 		51B526CB2A6C3988009DBFB4 /* DecidedPlanCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecidedPlanCell.swift; sourceTree = "<group>"; };
 		51C29AF22B31DD7600B1A1BA /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		51E8242A2B62AEEA00A56F3A /* KakaoLoginButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLoginButton.swift; sourceTree = "<group>"; };
 		51F2A4672A54804100D134CC /* ColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorExtension.swift; sourceTree = "<group>"; };
 		51F2A4692A548A1000D134CC /* FontExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontExtension.swift; sourceTree = "<group>"; };
 		51F2A4702A5497A500D134CC /* AuthAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthAPI.swift; sourceTree = "<group>"; };
@@ -563,6 +565,7 @@
 			isa = PBXGroup;
 			children = (
 				1AE23DBA2A59837F000D498F /* LoginViewController.swift */,
+				51E8242A2B62AEEA00A56F3A /* KakaoLoginButton.swift */,
 			);
 			path = Login;
 			sourceTree = "<group>";
@@ -779,6 +782,7 @@
 				514D73D62A59D2FB00404E64 /* InquireViewController.swift in Sources */,
 				518F55D52A683780002D8F0F /* SignOutPopUpViewController.swift in Sources */,
 				236054F72A593F3B00CA991E /* HomeViewController.swift in Sources */,
+				51E8242B2B62AEEA00A56F3A /* KakaoLoginButton.swift in Sources */,
 				236054EF2A592B0C00CA991E /* TabbarViewController.swift in Sources */,
 				515E53BD2A77CF9400536C6D /* MeetingAPI.swift in Sources */,
 				2387E7582A7FCCEA0003044E /* MeetingMain.swift in Sources */,

--- a/CoNet/API/HomeAPI.swift
+++ b/CoNet/API/HomeAPI.swift
@@ -12,6 +12,7 @@ import KeychainSwift
 class HomeAPI {
     let baseUrl = "http://\(Bundle.main.infoDictionary?["BASE_URL"] ?? "nil baseUrl")"
     static let shared = HomeAPI()
+    let keychain = KeychainSwift()
     
     // 특정 달 약속 조회
     func getMonthPlan(date: String, completion: @escaping (_ count: Int, _ dates: [Int]) -> Void) {

--- a/CoNet/API/MeetingMainAPI.swift
+++ b/CoNet/API/MeetingMainAPI.swift
@@ -11,6 +11,7 @@ import KeychainSwift
 
 class MeetingMainAPI {
     let baseUrl = "http://\(Bundle.main.infoDictionary?["BASE_URL"] ?? "nil baseUrl")"
+    let keychain = KeychainSwift()
 
     // 팀 내 특정 달 약속 조회
     func getMeetingMonthPlan(teamId: Int, searchDate: String, completion: @escaping (_ count: Int, _ dates: [Int]) -> Void) {

--- a/CoNet/API/PlanTimeAPI.swift
+++ b/CoNet/API/PlanTimeAPI.swift
@@ -11,6 +11,7 @@ import KeychainSwift
 
 class PlanTimeAPI {
     let baseUrl = "http://\(Bundle.main.infoDictionary?["BASE_URL"] ?? "nil baseUrl")"
+    let keychain = KeychainSwift()
     
     // 구성원의 가능한 시간 조회
     func getMemberPossibleTime(planId: Int, completion: @escaping (_ teamId: Int, _ planId: Int, _ planName: String, _ planStartPeriod: String, _ planEndPeriod: String, _ sectionMemberCounts: [SectionMemberCounts], _ possibleMemberDateTime: [PossibleMemberDateTime]) -> Void) {

--- a/CoNet/Main/Auth/Login/AppleLoginButton.swift
+++ b/CoNet/Main/Auth/Login/AppleLoginButton.swift
@@ -1,0 +1,91 @@
+//
+//  AppleLoginButton.swift
+//  CoNet
+//
+//  Created by 이안진 on 1/26/24.
+//
+
+import SnapKit
+import Then
+import UIKit
+
+class AppleLoginButton: UIButton {
+    let button = UIButton().then {
+        $0.backgroundColor = .black
+        $0.layer.cornerRadius = 12
+    }
+    
+    let labelView = UIView().then {
+        $0.backgroundColor = UIColor.clear
+    }
+    
+    let image = UIImageView().then {
+        $0.image = UIImage(named: "apple")
+    }
+    
+    let label = UILabel().then {
+        $0.text = "Apple로 시작하기"
+        $0.font = UIFont.body1Bold
+        $0.textColor = UIColor.white
+    }
+    
+    // Custom View 초기화
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        addView()
+        layoutConstraints()
+        buttonActions()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        
+        addView()
+        layoutConstraints()
+        buttonActions()
+    }
+    
+    private func buttonActions() {
+        button.addTarget(self, action: #selector(appleLogin), for: .touchUpInside)
+    }
+    
+    var buttonAction: () -> Void = {}
+    @objc private func appleLogin() {
+        buttonAction()
+    }
+}
+
+extension AppleLoginButton {
+    private func addView() {
+        addSubview(button)
+        button.addSubview(labelView)
+        labelView.addSubview(image)
+        labelView.addSubview(label)
+    }
+    
+    private func layoutConstraints() {
+        button.snp.makeConstraints { make in
+            make.height.equalTo(52)
+            make.width.equalToSuperview()
+        }
+        
+        labelView.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+            make.width.equalTo(144)
+            make.height.equalTo(20)
+        }
+
+        image.snp.makeConstraints { make in
+            make.leading.equalToSuperview()
+            make.centerY.equalToSuperview()
+            make.width.equalTo(18)
+            make.height.equalTo(20)
+        }
+        
+        label.snp.makeConstraints { make in
+            make.leading.equalTo(image.snp.trailing).offset(10)
+            make.centerY.equalToSuperview()
+        }
+    }
+}

--- a/CoNet/Main/Auth/Login/AppleLoginButton.swift
+++ b/CoNet/Main/Auth/Login/AppleLoginButton.swift
@@ -5,11 +5,15 @@
 //  Created by 이안진 on 1/26/24.
 //
 
+import AuthenticationServices
+import KeychainSwift
 import SnapKit
 import Then
 import UIKit
 
-class AppleLoginButton: UIButton {
+class AppleLoginButton: UIViewController {
+    let keychain = KeychainSwift()
+    
     let button = UIButton().then {
         $0.backgroundColor = .black
         $0.layer.cornerRadius = 12
@@ -29,17 +33,11 @@ class AppleLoginButton: UIButton {
         $0.textColor = UIColor.white
     }
     
-    // Custom View 초기화
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    override func viewDidLoad() {
+        super.viewDidLoad()
         
-        addView()
-        layoutConstraints()
-        buttonActions()
-    }
-    
-    required init?(coder: NSCoder) {
-        super.init(coder: coder)
+        // 배경색 .white로 지정
+        view.backgroundColor = .white
         
         addView()
         layoutConstraints()
@@ -50,15 +48,77 @@ class AppleLoginButton: UIButton {
         button.addTarget(self, action: #selector(appleLogin), for: .touchUpInside)
     }
     
-    var buttonAction: () -> Void = {}
     @objc private func appleLogin() {
-        buttonAction()
+        // request 생성
+        let request = ASAuthorizationAppleIDProvider().createRequest()
+        request.requestedScopes = [.fullName, .email]
+            
+        // request를 보내줄 controller 생성
+        let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+        authorizationController.delegate = self as ASAuthorizationControllerDelegate
+        authorizationController.presentationContextProvider = self as ASAuthorizationControllerPresentationContextProviding
+            
+        // 요청 보내기
+        authorizationController.performRequests()
+    }
+    
+    private func postAppleLogin() {
+        // apple login api 호출
+        AuthAPI.shared.appleLogin { isRegistered in
+            if isRegistered {
+                // 홈 탭으로 이동
+                let nextVC = TabbarViewController()
+                self.navigationController?.pushViewController(nextVC, animated: true)
+                    
+                // 루트뷰를 홈 탭으로 바꾸기 (스택 초기화)
+                let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate
+                sceneDelegate?.changeRootVC(TabbarViewController(), animated: false)
+            } else {
+                // 회원가입 탭으로 이동
+                let nextVC = TermsOfUseViewController()
+                self.navigationController?.pushViewController(nextVC, animated: true)
+            }
+        }
     }
 }
 
+extension AppleLoginButton: ASAuthorizationControllerDelegate {
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        if let credential = authorization.credential as? ASAuthorizationAppleIDCredential {
+            let idToken = credential.identityToken!
+            let tokenStr = String(data: idToken, encoding: .utf8)
+            print("idToken: ", tokenStr ?? "")
+                
+            guard let code = credential.authorizationCode else { return }
+            let codeStr = String(data: code, encoding: .utf8)
+            print(codeStr ?? "")
+                
+            let user = credential.user
+            print(user)
+                
+            // idToken 저장
+            keychain.set(tokenStr ?? "", forKey: "idToken")
+                
+            // apple login api 호출
+            postAppleLogin()
+        }
+    }
+        
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        print("Apple login error: \(error)")
+    }
+}
+
+extension AppleLoginButton: ASAuthorizationControllerPresentationContextProviding {
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        return view.window!
+    }
+}
+
+// addView & layoutConstraints
 extension AppleLoginButton {
     private func addView() {
-        addSubview(button)
+        view.addSubview(button)
         button.addSubview(labelView)
         labelView.addSubview(image)
         labelView.addSubview(label)

--- a/CoNet/Main/Auth/Login/KakaoLoginButton.swift
+++ b/CoNet/Main/Auth/Login/KakaoLoginButton.swift
@@ -33,19 +33,30 @@ class KakaoLoginButton: UIButton {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-        // layout
         addView()
         layoutConstraints()
+        buttonActions()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         
-        // layout
         addView()
         layoutConstraints()
+        buttonActions()
     }
     
+    private func buttonActions() {
+        button.addTarget(self, action: #selector(kakaoLogin), for: .touchUpInside)
+    }
+    
+    var buttonAction: () -> Void = {}
+    @objc private func kakaoLogin() {
+        buttonAction()
+    }
+}
+
+extension KakaoLoginButton {
     private func addView() {
         addSubview(button)
         button.addSubview(labelView)

--- a/CoNet/Main/Auth/Login/KakaoLoginButton.swift
+++ b/CoNet/Main/Auth/Login/KakaoLoginButton.swift
@@ -1,0 +1,80 @@
+//
+//  KakaoLoginButton.swift
+//  CoNet
+//
+//  Created by 이안진 on 1/25/24.
+//
+
+import SnapKit
+import Then
+import UIKit
+
+class KakaoLoginButton: UIButton {
+    let button = UIButton().then {
+        $0.backgroundColor = UIColor(red: 0.976, green: 0.922, blue: 0, alpha: 1)
+        $0.layer.cornerRadius = 12
+    }
+    
+    let labelView = UIView().then {
+        $0.backgroundColor = UIColor.clear
+    }
+    
+    let image = UIImageView().then {
+        $0.image = UIImage(named: "kakao")
+    }
+    
+    let label = UILabel().then {
+        $0.text = "카카오톡으로 시작하기"
+        $0.font = UIFont.body1Bold
+        $0.textColor = UIColor.black
+    }
+    
+    // Custom View 초기화
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        // layout
+        addView()
+        layoutConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        
+        // layout
+        addView()
+        layoutConstraints()
+    }
+    
+    private func addView() {
+        addSubview(button)
+        button.addSubview(labelView)
+        labelView.addSubview(image)
+        labelView.addSubview(label)
+    }
+    
+    private func layoutConstraints() {
+        button.snp.makeConstraints { make in
+            make.height.equalTo(52)
+            make.width.equalToSuperview()
+        }
+        
+        labelView.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+            make.width.equalTo(172)
+            make.height.equalTo(22)
+        }
+
+        image.snp.makeConstraints { make in
+            make.leading.equalToSuperview()
+            make.centerY.equalToSuperview()
+            make.width.equalTo(22)
+            make.height.equalTo(20)
+        }
+        
+        label.snp.makeConstraints { make in
+            make.leading.equalTo(image.snp.trailing).offset(10)
+            make.centerY.equalToSuperview()
+        }
+    }
+}

--- a/CoNet/Main/Auth/Login/LoginViewController.swift
+++ b/CoNet/Main/Auth/Login/LoginViewController.swift
@@ -30,6 +30,12 @@ class LoginViewController: UIViewController {
         $0.textColor = .black
     }
     
+    let logoImageView = UIImageView().then {
+        $0.image = UIImage(named: "LaunchScreenImage")
+        $0.contentMode = .scaleAspectFit
+        $0.backgroundColor = .clear
+    }
+    
     let kakaoLoginButtonReal = KakaoLoginButton()
     
     override func viewDidLoad() {
@@ -80,23 +86,7 @@ class LoginViewController: UIViewController {
     // MARK: - UI Setup
     
     private func setupUI() {
-        setupLogoImageView()
         setupAppleButton()
-    }
-
-    private func setupLogoImageView() {
-        let logoImageView = UIImageView().then {
-            $0.image = UIImage(named: "LaunchScreenImage")
-            $0.contentMode = .scaleAspectFit
-            $0.backgroundColor = .clear
-        }
-        view.addSubview(logoImageView)
-        logoImageView.snp.makeConstraints { make in
-            make.top.equalToSuperview().offset(266)
-            make.left.equalToSuperview().offset(130)
-            make.right.equalToSuperview().offset(-130)
-            make.height.equalTo(198.64)
-        }
     }
         
     private func setupAppleButton() {
@@ -280,6 +270,7 @@ extension LoginViewController {
     private func addView() {
         view.addSubview(kakaoLoginButtonReal)
         view.addSubview(sloganLabel)
+        view.addSubview(logoImageView)
     }
     
     private func layoutConstraints() {
@@ -291,6 +282,12 @@ extension LoginViewController {
         
         sloganLabel.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(200)
+            make.centerX.equalToSuperview()
+        }
+        
+        logoImageView.snp.makeConstraints { make in
+            make.height.equalTo(200)
+            make.top.equalTo(sloganLabel.snp.bottom).offset(30)
             make.centerX.equalToSuperview()
         }
     }

--- a/CoNet/Main/Auth/Login/LoginViewController.swift
+++ b/CoNet/Main/Auth/Login/LoginViewController.swift
@@ -24,6 +24,12 @@ class LoginViewController: UIViewController {
         $0.setTitleColor(UIColor.purpleMain, for: .normal)
     }
     
+    let sloganLabel = UILabel().then {
+        $0.text = "맞춰가는 시간, 만들어가는 추억"
+        $0.font = UIFont.headline3Regular
+        $0.textColor = .black
+    }
+    
     let kakaoLoginButtonReal = KakaoLoginButton()
     
     override func viewDidLoad() {
@@ -71,38 +77,11 @@ class LoginViewController: UIViewController {
         sceneDelegate?.changeRootVC(TabbarViewController(), animated: false)
     }
     
-    
-    
     // MARK: - UI Setup
     
     private func setupUI() {
-        setupTitleLabel()
         setupLogoImageView()
         setupAppleButton()
-    }
-    
-    private func setupTitleLabel() {
-        let titleLabel = UILabel().then {
-            $0.text = "맞춰가는 시간, 만들어가는 추억"
-            $0.font = UIFont.headline3Regular
-            $0.textColor = .black
-            
-            let paragraphStyle = NSMutableParagraphStyle()
-            paragraphStyle.lineHeightMultiple = 1.02
-            
-            let attributedText = NSMutableAttributedString(string: "맞춰가는 시간, 만들어가는 추억", attributes: [
-                NSAttributedString.Key.kern: -0.45,
-                NSAttributedString.Key.paragraphStyle: paragraphStyle
-            ])
-            $0.attributedText = attributedText
-        }
-        view.addSubview(titleLabel)
-        titleLabel.snp.makeConstraints { make in
-            make.top.equalToSuperview().offset(214)
-            make.centerX.equalToSuperview().offset(0.5)
-            make.width.equalTo(220)
-            make.height.equalTo(22)
-        }
     }
 
     private func setupLogoImageView() {
@@ -300,6 +279,7 @@ extension LoginViewController {
     
     private func addView() {
         view.addSubview(kakaoLoginButtonReal)
+        view.addSubview(sloganLabel)
     }
     
     private func layoutConstraints() {
@@ -307,6 +287,11 @@ extension LoginViewController {
             make.height.equalTo(52)
             make.horizontalEdges.equalTo(view.snp.horizontalEdges).inset(24)
             make.top.equalTo(view.snp.top).offset(100)
+        }
+        
+        sloganLabel.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(200)
+            make.centerX.equalToSuperview()
         }
     }
 }

--- a/CoNet/Main/Auth/Login/LoginViewController.swift
+++ b/CoNet/Main/Auth/Login/LoginViewController.swift
@@ -24,11 +24,21 @@ class LoginViewController: UIViewController {
         $0.setTitleColor(UIColor.purpleMain, for: .normal)
     }
     
+    let kakaoLoginButtonReal = KakaoLoginButton()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        setupUI()
+        // 배경색 .white로 지정
+        view.backgroundColor = .white
+        
         tempButtonUI()
+        
+        addView()
+        layoutConstraints()
+        buttonActions()
+        
+        setupUI()
         
         showSignUpButton.addTarget(self, action: #selector(showSignUp(_:)), for: .touchUpInside)
         showMainButton.addTarget(self, action: #selector(showMain(_:)), for: .touchUpInside)
@@ -44,6 +54,10 @@ class LoginViewController: UIViewController {
         }
     }
     
+    private func buttonActions() {
+        kakaoLoginButtonReal.addTarget(self, action: #selector(kakaoButtonTapped), for: .touchUpInside)
+    }
+    
     @objc func showSignUp(_ sender: UIView) {
         let nextVC = TermsOfUseViewController()
         navigationController?.pushViewController(nextVC, animated: true)
@@ -57,29 +71,13 @@ class LoginViewController: UIViewController {
         sceneDelegate?.changeRootVC(TabbarViewController(), animated: false)
     }
     
-    func tempButtonUI() {
-        let safeArea = view.safeAreaLayoutGuide
-        
-        view.addSubview(showSignUpButton)
-        showSignUpButton.snp.makeConstraints { make in
-            make.centerX.equalTo(safeArea.snp.centerX)
-            make.bottom.equalTo(safeArea.snp.bottom).offset(-60)
-        }
-        
-        view.addSubview(showMainButton)
-        showMainButton.snp.makeConstraints { make in
-            make.centerX.equalTo(safeArea.snp.centerX)
-            make.bottom.equalTo(safeArea.snp.bottom).offset(-30)
-        }
-    }
+    
     
     // MARK: - UI Setup
     
     private func setupUI() {
-        view.backgroundColor = .white
         setupTitleLabel()
         setupLogoImageView()
-        setupKakaoButton()
         setupAppleButton()
     }
     
@@ -120,58 +118,6 @@ class LoginViewController: UIViewController {
             make.right.equalToSuperview().offset(-130)
             make.height.equalTo(198.64)
         }
-    }
-
-    private func setupKakaoButton() {
-        let kakaoButton = UIButton().then {
-            $0.backgroundColor = UIColor(red: 0.976, green: 0.922, blue: 0, alpha: 1)
-            $0.layer.cornerRadius = 12
-            $0.addTarget(self, action: #selector(kakaoButtonTapped), for: .touchUpInside)
-        }
-        view.addSubview(kakaoButton)
-        kakaoButton.snp.makeConstraints { make in
-            make.top.equalToSuperview().offset(574)
-            make.left.equalToSuperview().offset(24)
-            make.right.equalToSuperview().offset(-24)
-            make.height.equalTo(52)
-        }
-        
-        let kakaoStackView = UIStackView().then {
-            $0.axis = .horizontal
-            $0.spacing = 8
-        }
-        kakaoButton.addSubview(kakaoStackView)
-        kakaoStackView.snp.makeConstraints { make in
-            make.centerX.centerY.equalToSuperview()
-        }
-        
-        let kakaoImageView = UIImageView().then {
-            $0.image = UIImage(named: "kakao")
-            $0.contentMode = .scaleAspectFit
-            $0.backgroundColor = .clear
-            $0.transform = CGAffineTransform(scaleX: 1, y: 1.02)
-        }
-        kakaoStackView.addArrangedSubview(kakaoImageView)
-        kakaoImageView.snp.makeConstraints { make in
-            make.width.equalTo(21)
-            make.height.equalTo(19)
-        }
-        
-        let kakaoLabel = UILabel().then {
-            $0.text = "카카오톡으로 3초만에 시작하기"
-            $0.font = UIFont.body1Bold
-            $0.textColor = .black
-            
-            let paragraphStyle = NSMutableParagraphStyle()
-            paragraphStyle.lineHeightMultiple = 1.05
-            
-            let attributedText = NSMutableAttributedString(string: "카카오톡으로 3초만에 시작하기", attributes: [
-                NSAttributedString.Key.kern: -0.4,
-                NSAttributedString.Key.paragraphStyle: paragraphStyle
-            ])
-            $0.attributedText = attributedText
-        }
-        kakaoStackView.addArrangedSubview(kakaoLabel)
     }
         
     private func setupAppleButton() {
@@ -334,9 +280,38 @@ class LoginViewController: UIViewController {
     }
 }
 
-let keychain = KeychainSwift()
+// addView & layoutConstraints
+extension LoginViewController {
+    private func tempButtonUI() {
+        let safeArea = view.safeAreaLayoutGuide
+        
+        view.addSubview(showSignUpButton)
+        showSignUpButton.snp.makeConstraints { make in
+            make.centerX.equalTo(safeArea.snp.centerX)
+            make.bottom.equalTo(safeArea.snp.bottom).offset(-40)
+        }
+        
+        view.addSubview(showMainButton)
+        showMainButton.snp.makeConstraints { make in
+            make.centerX.equalTo(safeArea.snp.centerX)
+            make.bottom.equalTo(safeArea.snp.bottom).offset(-10)
+        }
+    }
+    
+    private func addView() {
+        view.addSubview(kakaoLoginButtonReal)
+    }
+    
+    private func layoutConstraints() {
+        kakaoLoginButtonReal.snp.makeConstraints { make in
+            make.height.equalTo(52)
+            make.horizontalEdges.equalTo(view.snp.horizontalEdges).inset(24)
+            make.top.equalTo(view.snp.top).offset(100)
+        }
+    }
+}
 
-// MARK: - ASAuthorizationControllerDelegate
+let keychain = KeychainSwift()
 
 // apple login
 extension LoginViewController: ASAuthorizationControllerDelegate {
@@ -380,17 +355,18 @@ extension LoginViewController: ASAuthorizationControllerDelegate {
     }
 }
 
-// MARK: - ASAuthorizationControllerPresentationContextProviding
-
 extension LoginViewController: ASAuthorizationControllerPresentationContextProviding {
     func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
         return view.window!
     }
 }
     
-private func createButton(color: UIColor) -> UIButton {
-    return UIButton().then {
-        $0.backgroundColor = color
-        $0.layer.cornerRadius = 12
+#if canImport(SwiftUI) && DEBUG
+import SwiftUI
+
+struct LoginViewControllerPreview: PreviewProvider {
+    static var previews: some View {
+        LoginViewController().showPreview(.iPhone14Pro)
     }
 }
+#endif

--- a/CoNet/SceneDelegate.swift
+++ b/CoNet/SceneDelegate.swift
@@ -11,14 +11,14 @@ import UIKit
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
-    
-//    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
-//            if let url = URLContexts.first?.url {
-//                if AuthApi.isKakaoTalkLoginUrl(url) {
-//                    _ = AuthController.handleOpenUrl(url: url)
-//                }
-//        }
-//    }
+
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        if let url = URLContexts.first?.url {
+            if AuthApi.isKakaoTalkLoginUrl(url) {
+                _ = AuthController.handleOpenUrl(url: url)
+            }
+        }
+    }
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }


### PR DESCRIPTION
<!-- PR 제목은
      [PR] 어떤 내용입니다!
      로 해주세요~!! -->

## PR Type ⚙️
<!-- 어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크 후 남겨줍니다.
      사용하지 않는 리스트는 삭제해주세요! -->
      
- [x] Feat: 새로운 기능을 추가
- [x] Fix: 버그 수정
- [x] Refactor: 프로덕션 코드 리팩토링

<br>


## What is this PR? 📝

### Related Issue Number
<!-- 연관된 이슈 번호를 모두 작성해 주세요. ex, #23, #24 -->
- #61 
<br>

### Changes
<!-- PR의 작업 내용에 대한 설명을 적습니다. - 추가/변경사항에 대해 작성해주세요. -->
- 로그인 화면의 카카오톡, 애플 로그인 버튼을 UIViewController로 분리했어요
  - 로그인 VC의 역할을 전부 줄이고, 각 버튼의 동작은 각 VC 내부로 넣었습니다!
- 카카오톡 앱으로 로그인 오류가 있었는데, 수정했습니다
  - 요거 수정하면서 SceneDelegate 파일 수정했어요!
- keychain 변수가 class 내부에 들어가 있지 않고 밖으로 나와 있어서 안으로 넣어주었어요
  - 그랬더니 다른 api들에 keychain이 선언되어 있지 않아 생긴 오류들이 나와서 API 안에 keychain을 넣어주었습니다!
<br>

### ScreenShots
<!--
뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
적절한 사이즈로 첨부하는 코드 👇

-->
<img width="300" alt="" src="https://github.com/KUIT-CoNet/CoNet-iOS/assets/117328806/95367279-2ba4-4fc3-a8b3-aea01f0151e6">

<br>


## Other information 🔥
<!-- 기타 참고사항이 있다면 작성해줍니다. -->
- LoginViewController 에 Apple Login 관련 내용 그리고 Kakao Login 관련 내용은 각 버튼 내부로 넣고 싶었는데.. ViewController에 엮인 아이들이 많아서 실패했습니다.. 후.. 다음번엔 성공할게요 후후.
- 라고 원래 썼었는데, ViewController 안에 다른 ViewController를 넣을 수 있다는 사실을 알고 변경했어요!
- 코드가 수정된 사항이 많아서 보기 어려울 것 같은데 죄송함당.. (하지만 전부 하나의 파일을 리팩토링하면서 생긴 내용들이라.. 어쩔 수 없었ㅇㅓ여 ㅠㅜ)
<br>



