### PR TITLE
[PR] 약속확정 팝업, 상세페이지 리팩토링

### DIFF
--- a/CoNet/Main/Components/Plan/FixPlanPopUpView.swift
+++ b/CoNet/Main/Components/Plan/FixPlanPopUpView.swift
@@ -47,13 +47,20 @@ class FixPlanPopUpView: UIView {
     }
     
     // 가로 구분선
-    let horizontalDivider = UIView().then { $0.backgroundColor = UIColor.gray100 }
+    let horizontalDivider = UIView().then {
+        $0.backgroundColor = UIColor.gray100
+    }
     
     // 세로 짧은 구분선
-    let verticalDivider = UIView().then { $0.backgroundColor = UIColor.gray100 }
+    let verticalDivider = UIView().then {
+        $0.backgroundColor = UIColor.gray100
+    }
     
     // 왼쪽 버튼
-    let leftButton = UIButton().then { $0.backgroundColor = .clear }
+    let leftButton = UIButton().then {
+        $0.backgroundColor = .clear
+    }
+    
     let leftButtonTitle = UILabel().then {
         $0.text = "취소"
         $0.font = UIFont.body1Medium
@@ -61,7 +68,10 @@ class FixPlanPopUpView: UIView {
     }
     
     // 오른쪽 버튼
-    let rightButton = UIButton().then { $0.backgroundColor = .clear }
+    let rightButton = UIButton().then {
+        $0.backgroundColor = .clear
+    }
+    
     let rightButtonTitle = UILabel().then {
         $0.text = "확정"
         $0.font = UIFont.body1Bold
@@ -71,100 +81,16 @@ class FixPlanPopUpView: UIView {
     // Custom View 초기화
     override init(frame: CGRect) {
         super.init(frame: frame)
-        setupViews()
+        addView()
+        layoutConstraints()
         buttonActions()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-        setupViews()
+        addView()
+        layoutConstraints()
         buttonActions()
-    }
-    
-    // 구성 요소들을 Custom View에 추가하고 레이아웃 설정
-    private func setupViews() {
-        contentsConstraints()
-        buttonsConstraints()
-    }
-    
-    private func contentsConstraints() {
-        addSubview(background)
-        background.snp.makeConstraints { make in
-            make.width.equalToSuperview().offset(-48)
-            make.height.equalTo(340)
-        }
-        
-        background.addSubview(dateLabel)
-        dateLabel.snp.makeConstraints { make in
-            make.height.equalTo(22)
-            make.centerX.equalTo(background.snp.centerX)
-            make.top.equalTo(background.snp.top).offset(48)
-        }
-        
-        background.addSubview(timeLabel)
-        timeLabel.snp.makeConstraints { make in
-            make.height.equalTo(22)
-            make.centerX.equalTo(background.snp.centerX)
-            make.top.equalTo(dateLabel.snp.bottom).offset(6)
-        }
-        
-        background.addSubview(membersLabel)
-        membersLabel.snp.makeConstraints { make in
-            make.centerX.equalTo(background.snp.centerX)
-            make.top.equalTo(timeLabel.snp.bottom).offset(14)
-        }
-    }
-    
-    private func buttonsConstraints() {
-        background.addSubview(horizontalDivider)
-        horizontalDivider.snp.makeConstraints { make in
-            make.height.equalTo(1)
-            make.width.equalTo(background.snp.width)
-            make.bottom.equalTo(background.snp.bottom).offset(-60)
-        }
-        
-        background.addSubview(fixPlanLabel)
-        fixPlanLabel.snp.makeConstraints { make in
-            make.height.equalTo(20)
-            make.centerX.equalTo(background.snp.centerX)
-            make.bottom.equalTo(horizontalDivider.snp.top).offset(-58)
-        }
-        
-        background.addSubview(verticalDivider)
-        verticalDivider.snp.makeConstraints { make in
-            make.height.equalTo(24)
-            make.width.equalTo(1)
-            make.centerX.equalTo(background.snp.centerX)
-            make.bottom.equalTo(background.snp.bottom).offset(-18)
-        }
-        
-        background.addSubview(leftButton)
-        leftButton.snp.makeConstraints { make in
-            make.width.equalTo(background.snp.width).dividedBy(2)
-            make.height.equalTo(60)
-            make.leading.equalTo(background.snp.leading)
-            make.bottom.equalTo(background.snp.bottom)
-        }
-        
-        leftButton.addSubview(leftButtonTitle)
-        leftButtonTitle.snp.makeConstraints { make in
-            make.height.equalTo(20)
-            make.center.equalTo(leftButton.snp.center)
-        }
-        
-        background.addSubview(rightButton)
-        rightButton.snp.makeConstraints { make in
-            make.width.equalTo(background.snp.width).dividedBy(2)
-            make.height.equalTo(60)
-            make.trailing.equalTo(background.snp.trailing)
-            make.bottom.equalTo(background.snp.bottom)
-        }
-        
-        rightButton.addSubview(rightButtonTitle)
-        rightButtonTitle.snp.makeConstraints { make in
-            make.height.equalTo(20)
-            make.center.equalTo(rightButton.snp.center)
-        }
     }
     
     // 버튼 action
@@ -193,5 +119,100 @@ class FixPlanPopUpView: UIView {
     
     func setMembers(_ title: String) {
         membersLabel.text = title
+    }
+}
+
+// addView, layout
+extension FixPlanPopUpView {
+    func addView() {
+        addSubview(background)
+        background.addSubview(dateLabel)
+        background.addSubview(timeLabel)
+        background.addSubview(membersLabel)
+        background.addSubview(horizontalDivider)
+        background.addSubview(fixPlanLabel)
+        background.addSubview(verticalDivider)
+        background.addSubview(leftButton)
+        leftButton.addSubview(leftButtonTitle)
+        background.addSubview(rightButton)
+        rightButton.addSubview(rightButtonTitle)
+    }
+    
+    // 구성 요소들을 Custom View에 추가하고 레이아웃 설정
+    private func layoutConstraints() {
+        contentsConstraints()
+        buttonsConstraints()
+    }
+    
+    private func contentsConstraints() {
+        let screenWidth = UIScreen.main.bounds.size.width
+        let screenHeight = UIScreen.main.bounds.size.height
+        
+        background.snp.makeConstraints { make in
+            make.width.equalTo(screenWidth*0.8)
+            make.height.equalTo(screenHeight*0.35)
+        }
+    
+        dateLabel.snp.makeConstraints { make in
+            make.height.equalTo(22)
+            make.centerX.equalTo(background.snp.centerX)
+            make.top.equalTo(background.snp.top).offset(48)
+        }
+        
+        timeLabel.snp.makeConstraints { make in
+            make.height.equalTo(22)
+            make.centerX.equalTo(background.snp.centerX)
+            make.top.equalTo(dateLabel.snp.bottom).offset(6)
+        }
+        
+        membersLabel.snp.makeConstraints { make in
+            make.centerX.equalTo(background.snp.centerX)
+            make.top.equalTo(timeLabel.snp.bottom).offset(14)
+        }
+    }
+    
+    private func buttonsConstraints() {
+        horizontalDivider.snp.makeConstraints { make in
+            make.height.equalTo(1)
+            make.width.equalTo(background.snp.width)
+            make.bottom.equalTo(background.snp.bottom).offset(-60)
+        }
+        
+        fixPlanLabel.snp.makeConstraints { make in
+            make.height.equalTo(20)
+            make.centerX.equalTo(background.snp.centerX)
+            make.bottom.equalTo(horizontalDivider.snp.top).offset(-58)
+        }
+        
+        verticalDivider.snp.makeConstraints { make in
+            make.height.equalTo(24)
+            make.width.equalTo(1)
+            make.centerX.equalTo(background.snp.centerX)
+            make.bottom.equalTo(background.snp.bottom).offset(-18)
+        }
+        
+        leftButton.snp.makeConstraints { make in
+            make.width.equalTo(background.snp.width).dividedBy(2)
+            make.height.equalTo(60)
+            make.leading.equalTo(background.snp.leading)
+            make.bottom.equalTo(background.snp.bottom)
+        }
+        
+        leftButtonTitle.snp.makeConstraints { make in
+            make.height.equalTo(20)
+            make.center.equalTo(leftButton.snp.center)
+        }
+        
+        rightButton.snp.makeConstraints { make in
+            make.width.equalTo(background.snp.width).dividedBy(2)
+            make.height.equalTo(60)
+            make.trailing.equalTo(background.snp.trailing)
+            make.bottom.equalTo(background.snp.bottom)
+        }
+        
+        rightButtonTitle.snp.makeConstraints { make in
+            make.height.equalTo(20)
+            make.center.equalTo(rightButton.snp.center)
+        }
     }
 }

--- a/CoNet/Main/Meeting/Plan/FixPlanInfoViewController.swift
+++ b/CoNet/Main/Meeting/Plan/FixPlanInfoViewController.swift
@@ -14,13 +14,16 @@ class FixPlanInfoViewController: UIViewController {
     var members: [PlanDetailMember] = []
     
     // 배경 - .clear
-    let scrollview = UIScrollView().then { $0.backgroundColor = .clear }
-    let contentsView = UIView().then { $0.backgroundColor = .clear }
+    let scrollview = UIScrollView().then {
+        $0.backgroundColor = .clear
+    }
     
-    let titleLabel = UILabel().then {
-        $0.text = "약속이 확정되었습니다!"
-        $0.font = UIFont.headline3Bold
-        $0.textColor = UIColor.black
+    let contentsView = UIView().then {
+        $0.backgroundColor = .clear
+    }
+    
+    let xButton = UIButton().then {
+        $0.setImage(UIImage(named: "closeBtn"), for: .normal)
     }
     
     // 약속 이름
@@ -69,23 +72,71 @@ class FixPlanInfoViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .white
         
-        navigationController?.navigationBar.isHidden = true
+        navigationController?.navigationBar.isHidden = false
+        navigationItem.title = "약속이 확정되었습니다!"
         
+        addView()
         layoutConstraints()
         setupCollectionView()
-        
-        completeButton.addTarget(self, action: #selector(didClickCompleteButton), for: .touchUpInside)
+        setupNavigationBar()
+        buttonActions()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        navigationController?.navigationBar.isHidden = true
+        navigationController?.navigationBar.isHidden = false
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        navigationController?.navigationBar.isHidden = true
+        navigationController?.navigationBar.isHidden = false
         
+        getPlanDetail()
+    }
+    
+    private func setupCollectionView() {
+        memberCollectionView.delegate = self
+        memberCollectionView.dataSource = self
+        memberCollectionView.register(MemberCollectionViewCell.self, forCellWithReuseIdentifier: MemberCollectionViewCell.cellId)
+    }
+    
+    func setupNavigationBar() {
+        let xButtonItem = UIBarButtonItem(customView: xButton)
+        navigationItem.leftBarButtonItem = xButtonItem
+    }
+    
+    func buttonActions() {
+        xButton.addTarget(self, action: #selector(xButtonTapped), for: .touchUpInside)
+        completeButton.addTarget(self, action: #selector(didClickCompleteButton), for: .touchUpInside)
+    }
+    
+    @objc private func showBottomSheet() {
+        let bottomSheetViewController = PlanEditDelBottomSheetViewController()
+        bottomSheetViewController.delegate = self
+        // 네비게이션 컨트롤러에 임베드
+        let navigationController = UINavigationController(rootViewController: bottomSheetViewController)
+        navigationController.modalPresentationStyle = .overCurrentContext
+        navigationController.modalTransitionStyle = .crossDissolve
+        present(navigationController, animated: true, completion: nil)
+    }
+    
+    @objc func xButtonTapped() {
+        if let navigationController = self.navigationController {
+            for controller in navigationController.viewControllers {
+                if let meetingMainVC = controller as? MeetingMainViewController {
+                    navigationController.popToViewController(meetingMainVC, animated: true)
+                    return
+                }
+            }
+        }
+    }
+    
+    @objc func didClickCompleteButton() {
+        navigationController?.popViewController(animated: false)
+        timeShareVC?.popPage()
+    }
+    
+    func getPlanDetail() {
         PlanAPI().getPlanDetail(planId: planId) { plans in
             self.nameRow.setText(plans.planName)
             self.dateRow.setText(plans.date)
@@ -95,111 +146,6 @@ class FixPlanInfoViewController: UIViewController {
             self.memberCollectionView.reloadData()
             
             self.layoutConstraints()
-        }
-    }
-    
-    private func setupCollectionView() {
-        memberCollectionView.delegate = self
-        memberCollectionView.dataSource = self
-        memberCollectionView.register(MemberCollectionViewCell.self, forCellWithReuseIdentifier: MemberCollectionViewCell.cellId)
-    }
-    
-    @objc private func showBottomSheet() {
-        let bottomSheetViewController = PlanEditDelBottomSheetViewController()
-        bottomSheetViewController.delegate = self
-        bottomSheetViewController.modalPresentationStyle = .overCurrentContext
-        bottomSheetViewController.modalTransitionStyle = .crossDissolve
-        present(bottomSheetViewController, animated: true, completion: nil)
-    }
-    
-    @objc func didClickCompleteButton() {
-        navigationController?.popViewController(animated: false)
-        timeShareVC?.popPage()
-    }
-    
-    // 전체 layout
-    private func layoutConstraints() {
-        viewConstraints()
-        rowConstraints()
-        memberConstraints()
-    }
-    
-    // scrollview, contentsview layout
-    private func viewConstraints() {
-        view.addSubview(scrollview)
-        scrollview.snp.makeConstraints { make in
-            make.edges.equalToSuperview().inset(0)
-        }
-        
-        scrollview.addSubview(contentsView)
-        contentsView.snp.makeConstraints { make in
-            make.edges.equalTo(scrollview.contentLayoutGuide)
-            make.width.equalTo(scrollview.frameLayoutGuide)
-            make.height.equalTo(1000)
-        }
-        
-        contentsView.addSubview(titleLabel)
-        titleLabel.snp.makeConstraints { make in
-            make.top.equalToSuperview().offset(41)
-            make.centerX.equalToSuperview()
-            make.height.equalTo(22)
-        }
-        
-        // 확인 버튼
-        view.addSubview(completeButton)
-        completeButton.snp.makeConstraints { make in
-            make.height.equalTo(52)
-            make.leading.trailing.equalToSuperview().inset(24)
-            make.bottom.equalTo(view.snp.bottom).offset(-35)
-        }
-    }
-    
-    // row layout
-    private func rowConstraints() {
-        contentsView.addSubview(nameRow)
-        nameRow.snp.makeConstraints { make in
-            make.width.equalToSuperview().offset(-48)
-            make.height.equalTo(54)
-            make.top.equalTo(titleLabel.snp.top).offset(46)
-            make.leading.equalTo(contentsView.snp.leading).offset(24)
-        }
-        
-        contentsView.addSubview(dateRow)
-        dateRow.snp.makeConstraints { make in
-            make.width.equalToSuperview().offset(-48)
-            make.height.equalTo(54)
-            make.top.equalTo(nameRow.snp.bottom).offset(26)
-            make.leading.equalTo(contentsView.snp.leading).offset(24)
-        }
-        
-        contentsView.addSubview(timeRow)
-        timeRow.snp.makeConstraints { make in
-            make.width.equalToSuperview().offset(-48)
-            make.height.equalTo(54)
-            make.top.equalTo(dateRow.snp.bottom).offset(26)
-            make.leading.equalTo(contentsView.snp.leading).offset(24)
-        }
-    }
-    
-    // 참여자 layout
-    private func memberConstraints() {
-        contentsView.addSubview(memberLabel)
-        memberLabel.snp.makeConstraints { make in
-            make.height.equalTo(14)
-            make.top.equalTo(timeRow.snp.bottom).offset(26)
-            make.leading.equalTo(contentsView.snp.leading).offset(24)
-        }
-        
-        contentsView.addSubview(memberCollectionView)
-        memberCollectionView.snp.makeConstraints { make in
-            make.width.equalToSuperview().offset(-48)
-            
-            let memberRow = ceil(Double(members.count) / 2.0)
-            let height = (memberRow * 42) + ((memberRow - 1) * 10)
-            make.height.equalTo(height)
-            
-            make.top.equalTo(memberLabel.snp.bottom).offset(14)
-            make.leading.trailing.equalToSuperview().inset(24)
         }
     }
 }
@@ -253,6 +199,93 @@ extension FixPlanInfoViewController: PlanInfoViewControllerDelegate {
             popUpVC.modalPresentationStyle = .overCurrentContext
             popUpVC.modalTransitionStyle = .crossDissolve
             present(popUpVC, animated: true, completion: nil)
+        }
+    }
+}
+
+// addView, layout
+extension FixPlanInfoViewController {
+    func addView() {
+        view.addSubview(scrollview)
+        scrollview.addSubview(contentsView)
+        view.addSubview(completeButton)
+        contentsView.addSubview(nameRow)
+        contentsView.addSubview(dateRow)
+        contentsView.addSubview(timeRow)
+        contentsView.addSubview(memberLabel)
+        contentsView.addSubview(memberCollectionView)
+    }
+    
+    // 전체 layout
+    private func layoutConstraints() {
+        viewConstraints()
+        rowConstraints()
+        memberConstraints()
+    }
+    
+    // scrollview, contentsview layout
+    private func viewConstraints() {
+        scrollview.snp.makeConstraints { make in
+            make.edges.equalToSuperview().inset(0)
+        }
+        
+        contentsView.snp.makeConstraints { make in
+            make.edges.equalTo(scrollview.contentLayoutGuide)
+            make.width.equalTo(scrollview.frameLayoutGuide)
+            make.height.equalTo(1000)
+        }
+        
+        // 확인 버튼
+        completeButton.snp.makeConstraints { make in
+            make.height.equalTo(52)
+            make.leading.trailing.equalToSuperview().inset(24)
+            make.bottom.equalTo(view.snp.bottom).offset(-35)
+        }
+    }
+    
+    // row layout
+    private func rowConstraints() {
+        let safeArea = view.safeAreaLayoutGuide
+        
+        nameRow.snp.makeConstraints { make in
+            make.width.equalToSuperview().offset(-48)
+            make.height.equalTo(54)
+            make.top.equalTo(safeArea.snp.top).offset(46)
+            make.leading.equalTo(contentsView.snp.leading).offset(24)
+        }
+    
+        dateRow.snp.makeConstraints { make in
+            make.width.equalToSuperview().offset(-48)
+            make.height.equalTo(54)
+            make.top.equalTo(nameRow.snp.bottom).offset(26)
+            make.leading.equalTo(contentsView.snp.leading).offset(24)
+        }
+        
+        timeRow.snp.makeConstraints { make in
+            make.width.equalToSuperview().offset(-48)
+            make.height.equalTo(54)
+            make.top.equalTo(dateRow.snp.bottom).offset(26)
+            make.leading.equalTo(contentsView.snp.leading).offset(24)
+        }
+    }
+    
+    // 참여자 layout
+    private func memberConstraints() {
+        memberLabel.snp.makeConstraints { make in
+            make.height.equalTo(14)
+            make.top.equalTo(timeRow.snp.bottom).offset(26)
+            make.leading.equalTo(contentsView.snp.leading).offset(24)
+        }
+        
+        memberCollectionView.snp.makeConstraints { make in
+            make.width.equalToSuperview().offset(-48)
+            
+            let memberRow = ceil(Double(members.count) / 2.0)
+            let height = (memberRow * 42) + ((memberRow - 1) * 10)
+            make.height.equalTo(height)
+            
+            make.top.equalTo(memberLabel.snp.bottom).offset(14)
+            make.horizontalEdges.equalToSuperview().inset(24)
         }
     }
 }

--- a/CoNet/Main/Meeting/Plan/FixPlanPopUpViewController.swift
+++ b/CoNet/Main/Meeting/Plan/FixPlanPopUpViewController.swift
@@ -5,10 +5,18 @@
 //  Created by 이안진 on 2023/08/08.
 //
 
+import SnapKit
+import Then
 import UIKit
 
 class FixPlanPopUpViewController: UIViewController, FixPlanDelegate {
     var planId: Int = 0
+    var date: String = "2023-07-03"
+    var weekOfDay: String = "월요일"
+    var time: Int = 0
+    var memberList: String = "이안진, 김미보, 김채린, 정아현"
+    var userIds: [Int] = []
+    var timeShareVC: TimeShareViewController?
     
     // 배경 - black 투명도 30%
     let background = UIView().then {
@@ -18,30 +26,44 @@ class FixPlanPopUpViewController: UIViewController, FixPlanDelegate {
     // 팝업
     let popUp = FixPlanPopUpView()
     
-    var date: String = "2023-07-03"
-    var weekOfDay: String = "월요일"
-    var time: Int = 0
-    var memberList: String = "이안진, 김미보, 김채린, 정아현"
-    var userIds: [Int] = []
-    
-    var timeShareVC: TimeShareViewController?
-    
     override func viewDidLoad() {
         super.viewDidLoad()
 
         // background color를 clear로 설정 (default: black)
         view.backgroundColor = .clear
         
+        addView()
         layoutConstraints()
+        buttonActions()
         
         popUp.delegate = self
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissPopUp))
-        background.addGestureRecognizer(tapGesture)
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
+        updatePopUp()
+    }
+    
+    func buttonActions() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissPopUp))
+        background.addGestureRecognizer(tapGesture)
+    }
+    
+    func cancel() {
+        dismissPopUp()
+    }
+    
+    func fixPlan() {
+        // 약속 확정 api 연동
+        PlanAPI().fixPlan(planId: planId, fixedDate: date, fixedTime: time, userId: userIds)
+        
+        dismiss(animated: true) {
+            self.timeShareVC?.pushFixPlanInfo(planId: self.planId)
+        }
+    }
+    
+    func updatePopUp() {
         let format = DateFormatter()
         format.dateFormat = "yyyy-MM-dd"
         
@@ -61,22 +83,17 @@ class FixPlanPopUpViewController: UIViewController, FixPlanDelegate {
         popUp.setMembers(memberList)
     }
     
-    func cancel() {
-        dismissPopUp()
-    }
-    
-    func fixPlan() {
-        // 약속 확정 api 연동
-        PlanAPI().fixPlan(planId: planId, fixedDate: date, fixedTime: time, userId: userIds)
-        
-        dismiss(animated: true) {
-            self.timeShareVC?.pushFixPlanInfo(planId: self.planId)
-        }
-    }
-    
     // 배경 탭 시 팝업 닫기
     @objc func dismissPopUp() {
         dismiss(animated: true)
+    }
+}
+
+// addView, layout
+extension FixPlanPopUpViewController {
+    func addView() {
+        view.addSubview(background)
+        view.addSubview(popUp)
     }
     
     // 모든 layout Constraints
@@ -87,7 +104,6 @@ class FixPlanPopUpViewController: UIViewController, FixPlanDelegate {
     
     // 배경 Constraints
     private func backgroundConstraints() {
-        view.addSubview(background)
         background.snp.makeConstraints { make in
             make.edges.equalToSuperview().inset(0)
         }
@@ -95,14 +111,13 @@ class FixPlanPopUpViewController: UIViewController, FixPlanDelegate {
     
     // 팝업 Constraints
     private func popUpConstraints() {
-        view.addSubview(popUp)
+        let screenWidth = UIScreen.main.bounds.size.width
+        let screenHeight = UIScreen.main.bounds.size.height
+        
         popUp.snp.makeConstraints { make in
-            make.height.equalTo(340)
-            make.leading.equalTo(view.snp.leading).offset(24)
-            make.trailing.equalTo(view.snp.trailing).offset(24)
-            
-            make.centerX.equalTo(view.snp.centerX)
-            make.centerY.equalTo(view.snp.centerY)
+            make.width.equalTo(screenWidth*0.8)
+            make.height.equalTo(screenHeight*0.35)
+            make.center.equalTo(view.snp.center)
         }
     }
 }


### PR DESCRIPTION
## PR Type ⚙️
- [x] Refactor: 프로덕션 코드 리팩토링

<br>


## What is this PR? 📝

### Related Issue Number
- #12 
<br>

### Changes
- [약속 확정 팝업, 팝업뷰] : 코드 구성 변경, 레이아웃 변경
- [약속 확정 상세 페이지] : 코드 구성 변경, 레이아웃 변경, 네비게이션 바 설정
<br>

### ScreenShots
<img width="300" alt="" src="https://github.com/KUIT-CoNet/CoNet-iOS/assets/121007805/053a2927-d858-4a44-aa1f-09b67b0a9281">
<img width="300" alt="" src="https://github.com/KUIT-CoNet/CoNet-iOS/assets/121007805/33bf3756-ba67-42c6-8ba1-25cc7a5621a9">

<br>


## Other information 🔥
- 모달로 띄우는 뷰가 있을 경우 네비게이션바가 나타나지않는 버그가 있었는데 그 버그를 해결하는 방법을 알아냈어요!!(모달로 띄우는 뷰를 네비게이션 컨트롤러에 임베드 하면 된다하네요..🤔)
- api 코드는 건들지 않고 레이아웃만 리팩토링 진행했습니당
<br>



