### PR TITLE
[PR] 로그인, 회원가입 API 변경사항 적용 완료 

### DIFF
--- a/CoNet/API/AuthAPI.swift
+++ b/CoNet/API/AuthAPI.swift
@@ -93,52 +93,19 @@ class AuthAPI {
         }
     }
     
-//    // MARK: kakao login
-//    func kakaoLogin(idToken: String, completion: @escaping (_ isRegistered: Bool) -> Void) {
-//        let url = "\(baseUrl)/auth/login/kakao"
-//        let headers: HTTPHeaders = ["Content-Type": "application/json"]
-//        let body: [String: Any] = [
-//            "idToken": idToken
-//        ]
-//        
-//        let dataRequest = AF.request(url, method: .post, parameters: body, encoding: JSONEncoding.default, headers: headers)
-//        
-//        dataRequest.responseDecodable(of: BaseResponse<PostKakaoLoginResult>.self) { response in
-//            switch response.result {
-//            case .success(let response):
-//                print("DEBUG(kakao login) access token: \(response.result?.accessToken ?? "")")
-//                print("DEBUG(kakao login) refresh token: \(response.result?.refreshToken ?? "")")
-//                
-//                guard let result = response.result else { return }
-//                
-//                self.keychain.set(result.email, forKey: "email")
-//                self.keychain.set(result.accessToken, forKey: "accessToken")
-//                self.keychain.set(result.refreshToken, forKey: "refreshToken")
-//                self.keychain.set(result.isRegistered, forKey: "kakaoIsRegistered")
-//                
-//                completion(response.result!.isRegistered)
-//                print(response.result!.isRegistered)
-//                
-//            case .failure(let error):
-//                print("DEBUG(kakao login api) error: \(error)")
-//            }
-//        }
-//    }
-    
     // signUp - 약관 동의, 이름 입력
-    func signUp(name: String, optionTerm: Bool, completion: @escaping (_ isSuccess: Bool) -> Void) {
-        let url = "\(baseUrl)/auth/term-and-name"
+    func signUp(name: String, completion: @escaping (_ isSuccess: Bool) -> Void) {
+        let url = "\(baseUrl)/auth/term"
         let headers: HTTPHeaders = [
             "Content-Type": "application/json",
             "Authorization": "Bearer \(keychain.get("accessToken") ?? "")"
         ]
         let body: [String: Any] = [
-            "name": name,
-            "optionTerm": optionTerm
+            "name": name
         ]
         
         AF.request(url, method: .post, parameters: body, encoding: JSONEncoding.default, headers: headers)
-            .responseDecodable(of: BaseResponse<PostSignUpResult>.self) { response in
+            .responseDecodable(of: BaseResponse<SignUpResponse>.self) { response in
             switch response.result {
             case .success(let response):  // 성공한 경우에
                 // 회원가입 성공 Bool 반환

--- a/CoNet/API/AuthAPI.swift
+++ b/CoNet/API/AuthAPI.swift
@@ -56,16 +56,18 @@ class AuthAPI {
             }
     }
     
-    // MARK: apple login
-    func appleLogin(completion: @escaping (_ isRegistered: Bool) -> Void) {
+    // login
+    // platform: apple or kakao
+    func login(platform: String, completion: @escaping (_ isRegistered: Bool) -> Void) {
         // 통신할 API 주소
-        let url = "\(baseUrl)/auth/login/apple"
+        let url = "\(baseUrl)/auth/login"
         
         // HTTP Headers : 요청 헤더
         let headers: HTTPHeaders = ["Content-Type": "application/json"]
         
         // request body
         let body: [String: Any] = [
+            "platform": platform,
             "idToken": keychain.get("idToken") ?? ""
         ]
         
@@ -74,20 +76,20 @@ class AuthAPI {
         
         // responseData를 호출하면서 데이터 통신 시작
         // response에 데이터 통신의 결과가 담깁니다.
-        dataRequest.responseDecodable(of: BaseResponse<PostAppleLoginResult>.self) { response in
+        dataRequest.responseDecodable(of: BaseResponse<LoginResponse>.self) { response in
             switch response.result {
             case .success(let response):  // 성공한 경우에
+                print(response.message)
                 print(response.result ?? "result empty")
                 
                 // 사용자 정보 저장
                 self.keychain.set(response.result!.email, forKey: "email")
                 self.keychain.set(response.result!.accessToken, forKey: "accessToken")
                 self.keychain.set(response.result!.refreshToken, forKey: "refreshToken")
-                self.keychain.set(response.result!.isRegistered, forKey: "appleIsRegistered")
                 completion(response.result!.isRegistered)
                 
             case .failure(let error):
-                print("DEBUG(apple login api) error: \(error)")
+                print("DEBUG(login api) error: \(error)")
             }
         }
     }

--- a/CoNet/API/AuthAPI.swift
+++ b/CoNet/API/AuthAPI.swift
@@ -11,7 +11,7 @@ import KeychainSwift
 
 class AuthAPI {
     let keychain = KeychainSwift()
-    let baseUrl = "http://\(Bundle.main.infoDictionary?["BASE_URL"] ?? "nil baseUrl")"
+    let baseUrl = "https://\(Bundle.main.infoDictionary?["BASE_URL"] ?? "nil baseUrl")"
     static let shared = AuthAPI()
     
     func regenerateToken(completion: @escaping (_ isSuccess: Bool) -> Void) {
@@ -82,10 +82,10 @@ class AuthAPI {
                 print(response.result ?? "result empty")
                 
                 // 사용자 정보 저장
-                self.keychain.set(response.result!.email, forKey: "email")
-                self.keychain.set(response.result!.accessToken, forKey: "accessToken")
-                self.keychain.set(response.result!.refreshToken, forKey: "refreshToken")
-                completion(response.result!.isRegistered)
+                self.keychain.set(response.result?.email ?? "", forKey: "email")
+                self.keychain.set(response.result?.accessToken ?? "", forKey: "accessToken")
+                self.keychain.set(response.result?.refreshToken ?? "", forKey: "refreshToken")
+                completion(response.result?.isRegistered ?? false)
                 
             case .failure(let error):
                 print("DEBUG(login api) error: \(error)")

--- a/CoNet/API/AuthAPI.swift
+++ b/CoNet/API/AuthAPI.swift
@@ -79,7 +79,6 @@ class AuthAPI {
         dataRequest.responseDecodable(of: BaseResponse<LoginResponse>.self) { response in
             switch response.result {
             case .success(let response):  // 성공한 경우에
-                print(response.message)
                 print(response.result ?? "result empty")
                 
                 // 사용자 정보 저장
@@ -94,37 +93,37 @@ class AuthAPI {
         }
     }
     
-    // MARK: kakao login
-    func kakaoLogin(idToken: String, completion: @escaping (_ isRegistered: Bool) -> Void) {
-        let url = "\(baseUrl)/auth/login/kakao"
-        let headers: HTTPHeaders = ["Content-Type": "application/json"]
-        let body: [String: Any] = [
-            "idToken": idToken
-        ]
-        
-        let dataRequest = AF.request(url, method: .post, parameters: body, encoding: JSONEncoding.default, headers: headers)
-        
-        dataRequest.responseDecodable(of: BaseResponse<PostKakaoLoginResult>.self) { response in
-            switch response.result {
-            case .success(let response):
-                print("DEBUG(kakao login) access token: \(response.result?.accessToken ?? "")")
-                print("DEBUG(kakao login) refresh token: \(response.result?.refreshToken ?? "")")
-                
-                guard let result = response.result else { return }
-                
-                self.keychain.set(result.email, forKey: "email")
-                self.keychain.set(result.accessToken, forKey: "accessToken")
-                self.keychain.set(result.refreshToken, forKey: "refreshToken")
-                self.keychain.set(result.isRegistered, forKey: "kakaoIsRegistered")
-                
-                completion(response.result!.isRegistered)
-                print(response.result!.isRegistered)
-                
-            case .failure(let error):
-                print("DEBUG(kakao login api) error: \(error)")
-            }
-        }
-    }
+//    // MARK: kakao login
+//    func kakaoLogin(idToken: String, completion: @escaping (_ isRegistered: Bool) -> Void) {
+//        let url = "\(baseUrl)/auth/login/kakao"
+//        let headers: HTTPHeaders = ["Content-Type": "application/json"]
+//        let body: [String: Any] = [
+//            "idToken": idToken
+//        ]
+//        
+//        let dataRequest = AF.request(url, method: .post, parameters: body, encoding: JSONEncoding.default, headers: headers)
+//        
+//        dataRequest.responseDecodable(of: BaseResponse<PostKakaoLoginResult>.self) { response in
+//            switch response.result {
+//            case .success(let response):
+//                print("DEBUG(kakao login) access token: \(response.result?.accessToken ?? "")")
+//                print("DEBUG(kakao login) refresh token: \(response.result?.refreshToken ?? "")")
+//                
+//                guard let result = response.result else { return }
+//                
+//                self.keychain.set(result.email, forKey: "email")
+//                self.keychain.set(result.accessToken, forKey: "accessToken")
+//                self.keychain.set(result.refreshToken, forKey: "refreshToken")
+//                self.keychain.set(result.isRegistered, forKey: "kakaoIsRegistered")
+//                
+//                completion(response.result!.isRegistered)
+//                print(response.result!.isRegistered)
+//                
+//            case .failure(let error):
+//                print("DEBUG(kakao login api) error: \(error)")
+//            }
+//        }
+//    }
     
     // signUp - 약관 동의, 이름 입력
     func signUp(name: String, optionTerm: Bool, completion: @escaping (_ isSuccess: Bool) -> Void) {

--- a/CoNet/DTO/Login.swift
+++ b/CoNet/DTO/Login.swift
@@ -15,9 +15,8 @@ struct LoginResponse: Codable {
 }
 
 // 회원가입 sign up
-struct PostSignUpResult: Codable {
+struct SignUpResponse: Codable {
     let name: String
     let email: String
     let serviceTerm: Bool
-    let optionTerm: Bool
 }

--- a/CoNet/DTO/Login.swift
+++ b/CoNet/DTO/Login.swift
@@ -14,14 +14,6 @@ struct LoginResponse: Codable {
     let isRegistered: Bool
 }
 
-// kakao login
-struct PostKakaoLoginResult: Codable {
-    let email: String
-    let accessToken: String
-    let refreshToken: String
-    let isRegistered: Bool
-}
-
 // 회원가입 sign up
 struct PostSignUpResult: Codable {
     let name: String

--- a/CoNet/DTO/Login.swift
+++ b/CoNet/DTO/Login.swift
@@ -7,8 +7,7 @@
 
 import Foundation
 
-// apple login
-struct PostAppleLoginResult: Codable {
+struct LoginResponse: Codable {
     let email: String
     let accessToken: String
     let refreshToken: String

--- a/CoNet/Main/Auth/Login/AppleLoginButton.swift
+++ b/CoNet/Main/Auth/Login/AppleLoginButton.swift
@@ -64,7 +64,7 @@ class AppleLoginButton: UIViewController {
     
     private func postAppleLogin() {
         // apple login api 호출
-        AuthAPI.shared.appleLogin { isRegistered in
+        AuthAPI.shared.login(platform: "apple") { isRegistered in
             if isRegistered {
                 // 홈 탭으로 이동
                 let nextVC = TabbarViewController()

--- a/CoNet/Main/Auth/Login/KakaoLoginButton.swift
+++ b/CoNet/Main/Auth/Login/KakaoLoginButton.swift
@@ -14,6 +14,8 @@ import Then
 import UIKit
 
 class KakaoLoginButton: UIViewController {
+    let keychain = KeychainSwift()
+    
     let button = UIButton().then {
         $0.backgroundColor = UIColor(red: 0.976, green: 0.922, blue: 0, alpha: 1)
         $0.layer.cornerRadius = 12
@@ -60,7 +62,8 @@ class KakaoLoginButton: UIViewController {
                     print("loginWithKakaoTalk() success")
                     print("Kakao id token: \(oauthToken?.idToken ?? "id token 없음..")")
                     
-                    self.postKakaoLogin(idToken: oauthToken?.idToken ?? "")
+                    self.keychain.set(oauthToken?.idToken ?? "", forKey: "idToken")
+                    self.postKakaoLogin()
                 }
             }
         } else {
@@ -74,14 +77,15 @@ class KakaoLoginButton: UIViewController {
                     print("loginWithKakaoTalkAccount() success")
                     print("Kakao id token: \(oauthToken?.idToken ?? "id token 없음..")")
                     
-                    self.postKakaoLogin(idToken: oauthToken?.idToken ?? "")
+                    self.keychain.set(oauthToken?.idToken ?? "", forKey: "idToken")
+                    self.postKakaoLogin()
                 }
             }
         }
     }
     
-    private func postKakaoLogin(idToken: String) {
-        AuthAPI.shared.kakaoLogin(idToken: idToken) { isRegistered in
+    private func postKakaoLogin() {
+        AuthAPI.shared.login(platform: "kakao") { isRegistered in
             if isRegistered {
                 // 홈 탭으로 이동
                 let nextVC = TabbarViewController()

--- a/CoNet/Main/Auth/SignUp/EnterNameViewController.swift
+++ b/CoNet/Main/Auth/SignUp/EnterNameViewController.swift
@@ -150,8 +150,6 @@ class EnterNameViewController: UIViewController, UITextFieldDelegate {
         let isButtonAvailable = name.isEmpty == false && isValidName(name)
         
         if isButtonAvailable {
-            let isOptionTermSelected = termsSelectedStates?[3] ?? false
-            
             AuthAPI().signUp(name: name) { isSuccess in
                 if isSuccess {
                     self.showTabBarViewController()

--- a/CoNet/Main/Auth/SignUp/EnterNameViewController.swift
+++ b/CoNet/Main/Auth/SignUp/EnterNameViewController.swift
@@ -152,7 +152,7 @@ class EnterNameViewController: UIViewController, UITextFieldDelegate {
         if isButtonAvailable {
             let isOptionTermSelected = termsSelectedStates?[3] ?? false
             
-            AuthAPI().signUp(name: name, optionTerm: isOptionTermSelected) { isSuccess in
+            AuthAPI().signUp(name: name) { isSuccess in
                 if isSuccess {
                     self.showTabBarViewController()
                 }


### PR DESCRIPTION
<!-- PR 제목은
      [PR] 어떤 내용입니다!
      로 해주세요~!! -->

## PR Type ⚙️
<!-- 어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크 후 남겨줍니다.
      사용하지 않는 리스트는 삭제해주세요! -->

<br>


## What is this PR? 📝

### Related Issue Number
<!-- 연관된 이슈 번호를 모두 작성해 주세요. ex, #23, #24 -->
- #70 
- #71 
<br>

### Changes
<!-- PR의 작업 내용에 대한 설명을 적습니다. - 추가/변경사항에 대해 작성해주세요. -->
- 이런 점들이 변경되었어요!
- 기존에 애플 로그인은 idToken을 keychain으로 저장하고 있었는데, 카카오 로그인은 따로 저장하지 않고 함수로 넘기고 있더라구요..! 그래서 keychain으로 저장하도록 변경했습니다 
- API 변경사항에 맞게 애플로그인과 카카오 로그인 API가 하나로 통합되었습니다
<br>

### ScreenShots
<!--
뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
적절한 사이즈로 첨부하는 코드 👇
<img width="300" alt="" src="이미지URL">
-->

<br>


## Other information 🔥
<!-- 기타 참고사항이 있다면 작성해줍니다. -->
- 리뷰하면서 이런 점들을 참고해주세요!
<br>



