### PR TITLE
[PR] plan 지난/다가오는 약속 기능 & api 

### DIFF
--- a/CoNet/API/PlanAPI.swift
+++ b/CoNet/API/PlanAPI.swift
@@ -36,7 +36,7 @@ class PlanAPI {
     }
     
     // 팀 내 확정된 지난/다가오는 약속 조회
-    func getDecidedPlansAtMeeting(meetingId: Int, period: String, completion: @escaping (_ count: Int, _ plans: [DecidedPlanInfo]) -> Void) {
+    func getDecidedPlansAtMeeting(meetingId: Int, period: String, status: Bool, completion: @escaping (_ count: Int, _ plans: [DecidedPlanInfo]) -> Void) {
         let url = "\(baseUrl)/plan/fixed?teamId=\(meetingId)&period=\(period)"
         let headers: HTTPHeaders = [
             "Content-Type": "application/json",
@@ -49,7 +49,21 @@ class PlanAPI {
                 case .success(let response):
                     guard let count = response.result?.count else { return }
                     guard let serverPlans = response.result?.plans else { return }
-                    completion(count, serverPlans)
+                    
+                    if !status {
+                        completion(count, serverPlans)
+                        return
+                    }
+                    
+                    var myPlans: [DecidedPlanInfo] = []
+                    for plan in serverPlans {
+                        if plan.participant {
+                            let myPlan = DecidedPlanInfo(planId: plan.planId, date: plan.date, time: plan.time, planName: plan.planName, participant: plan.participant, dday: plan.dday)
+                            myPlans.append(myPlan)
+                        }
+                    }
+                    
+                    completion(count, myPlans)
                     
                 case .failure(let error):
                     print("DEBUG(팀 내 확정된 지난/다가오는 약속 api) error: \(error)")

--- a/CoNet/API/PlanAPI.swift
+++ b/CoNet/API/PlanAPI.swift
@@ -90,7 +90,7 @@ class PlanAPI {
             "planName": planName,
             "time": time,
             "date": date ?? "",
-            "members": members ?? []
+            "memberIds": members ?? []
         ]
         
         AF.request(url, method: .post, parameters: requestBody, encoding: JSONEncoding.default, headers: headers)

--- a/CoNet/API/PlanAPI.swift
+++ b/CoNet/API/PlanAPI.swift
@@ -123,7 +123,7 @@ class PlanAPI {
     func updatePlan(planId: Int, planName: String, date: String?, time: String, members: [Int]?, completion: @escaping (_ isSuccess: Bool) -> Void) {
         let url = "\(baseUrl)/plan/update/fixed"
         let headers: HTTPHeaders = [
-            "Content-Type": "application/x-www-form-urlencoded",
+            "Content-Type": "application/json",
             "Authorization": "Bearer \(keychain.get("accessToken") ?? "")"
         ]
         
@@ -139,7 +139,7 @@ class PlanAPI {
             .responseDecodable(of: BaseResponse<String>.self) { response in
                 switch response.result {
                 case .success(let response):
-                    print("DEBUG(약속 상세 수정 api) success response: \(response)")
+                    print("DEBUG(약속 상세 수정 api) success response: \(response.message)")
                     completion(response.code == 1000)
                     
                 case .failure(let error):

--- a/CoNet/API/PlanAPI.swift
+++ b/CoNet/API/PlanAPI.swift
@@ -44,11 +44,11 @@ class PlanAPI {
         ]
         
         AF.request(url, method: .get, encoding: JSONEncoding.default, headers: headers)
-            .responseDecodable(of: BaseResponse<[DecidedPlanInfo]>.self) { response in
+            .responseDecodable(of: BaseResponse<GetPlansAtMeetingResult<[DecidedPlanInfo]>>.self) { response in
                 switch response.result {
                 case .success(let response):
                     guard let count = response.result?.count else { return }
-                    guard let serverPlans = response.result else { return }
+                    guard let serverPlans = response.result?.plans else { return }
                     completion(count, serverPlans)
                     
                 case .failure(let error):

--- a/CoNet/API/PlanAPI.swift
+++ b/CoNet/API/PlanAPI.swift
@@ -35,11 +35,12 @@ class PlanAPI {
             }
     }
     
-    // 팀 내 확정된 약속 조회
-    func getDecidedPlansAtMeeting(meetingId: Int, completion: @escaping (_ count: Int, _ plans: [DecidedPlanInfo]) -> Void) {
-        let url = "\(baseUrl)/team/plan/fixed?teamId=\(meetingId)"
+    // 팀 내 확정된 지난/다가오는 약속 조회
+    func getDecidedPlansAtMeeting(meetingId: Int, period: String, completion: @escaping (_ count: Int, _ plans: [DecidedPlanInfo]) -> Void) {
+        let url = "\(baseUrl)/plan/fixed?teamId=\(meetingId)&period=\(period)"
         let headers: HTTPHeaders = [
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
+            "Authorization": "Bearer \(keychain.get("accessToken") ?? "")"
         ]
         
         AF.request(url, method: .get, encoding: JSONEncoding.default, headers: headers)
@@ -51,50 +52,7 @@ class PlanAPI {
                     completion(count, serverPlans)
                     
                 case .failure(let error):
-                    print("DEBUG(팀 내 확정된 약속 api) error: \(error)")
-                }
-            }
-    }
-    
-    // 팀 내 지난 약속 조회
-    func getPastPlansAtMeeting(meetingId: Int, completion: @escaping (_ count: Int, _ plans: [PastPlanInfo]) -> Void) {
-        let url = "\(baseUrl)/team/plan/past?teamId=\(meetingId)"
-        let headers: HTTPHeaders = [
-            "Content-Type": "application/json"
-        ]
-        
-        AF.request(url, method: .get, encoding: JSONEncoding.default, headers: headers)
-            .responseDecodable(of: BaseResponse<[PastPlanInfo]>.self) { response in
-                switch response.result {
-                case .success(let response):
-                    guard let count = response.result?.count else { return }
-                    guard let serverPlans = response.result else { return }
-                    print(serverPlans)
-                    completion(count, serverPlans)
-                    
-                case .failure(let error):
-                    print("DEBUG(팀 내 지난 약속 api) error: \(error)")
-                }
-            }
-    }
-    
-    // 팀 내 지난 약속 조회
-    func getUnRegisteredPastPlansAtMeeting(meetingId: Int, completion: @escaping (_ plans: [PastPlanInfo]) -> Void) {
-        let url = "\(baseUrl)/team/plan/non-history?teamId=\(meetingId)"
-        let headers: HTTPHeaders = [
-            "Content-Type": "application/json"
-        ]
-        
-        AF.request(url, method: .get, encoding: JSONEncoding.default, headers: headers)
-            .responseDecodable(of: BaseResponse<[PastPlanInfo]>.self) { response in
-                switch response.result {
-                case .success(let response):
-                    guard let serverPlans = response.result else { return }
-                    print(serverPlans)
-                    completion(serverPlans)
-                    
-                case .failure(let error):
-                    print("DEBUG(팀 내 지난 약속 api) error: \(error)")
+                    print("DEBUG(팀 내 확정된 지난/다가오는 약속 api) error: \(error)")
                 }
             }
     }

--- a/CoNet/DTO/Plan.swift
+++ b/CoNet/DTO/Plan.swift
@@ -26,7 +26,7 @@ struct DecidedPlanInfo: Codable {
     let planId: Int
     let date, time: String
     let planName: String
-    let participant: String
+    let participant: Bool
     let dday: Int
 }
 

--- a/CoNet/DTO/Plan.swift
+++ b/CoNet/DTO/Plan.swift
@@ -25,15 +25,9 @@ struct WaitingPlanInfo: Codable {
 struct DecidedPlanInfo: Codable {
     let planId: Int
     let date, time: String
-    let teamName: String?
     let planName: String
+    let participant: String
     let dday: Int
-}
-
-struct PastPlanInfo: Codable {
-    let planId: Int
-    let date, time, planName: String
-    let isRegisteredToHistory: Bool
 }
 
 struct PlanDetail: Codable {

--- a/CoNet/Main/Plan/PlanDetail/PlanInfoEditViewController.swift
+++ b/CoNet/Main/Plan/PlanDetail/PlanInfoEditViewController.swift
@@ -231,7 +231,15 @@ class PlanInfoEditViewController: UIViewController, UITextFieldDelegate {
     }
     
     @objc private func updatePlan() {
+        date = planDateTextField.text?.replacingOccurrences(of: ". ", with: "-") ?? ""
+        updateUserId()
         // api 호출
+        PlanAPI().updatePlan(planId: planId, planName: planNameTextField.text ?? "", date: date, time: planTimeTextField.text ?? "", members: userIds) { isSuccess in
+            if isSuccess {
+                // 화면 끄기
+                self.dismiss(animated: true, completion: nil)
+            }
+        }
     }
     
     @objc private func xNameButtonTapped() {

--- a/CoNet/Main/Plan/PlanList/DecidedPlan/DecidedPlanListViewController.swift
+++ b/CoNet/Main/Plan/PlanList/DecidedPlan/DecidedPlanListViewController.swift
@@ -89,6 +89,7 @@ class DecidedPlanListViewController: UIViewController {
         let imageName = sender.isSelected ? "check-circle" : "uncheck-circle"
         sender.setImage(UIImage(named: imageName), for: .normal)
         
+        getDecidedPlan()
         mainView.collectionView.reloadData()
     }
     
@@ -113,7 +114,14 @@ class DecidedPlanListViewController: UIViewController {
             period = "past"
         }
         
-        PlanAPI().getDecidedPlansAtMeeting(meetingId: meetingId, period: period) { count, plans in
+        var status: Bool = false
+        if filterButton.isSelected {
+            status = true
+        } else {
+            status = false
+        }
+        
+        PlanAPI().getDecidedPlansAtMeeting(meetingId: meetingId, period: period, status: status) { count, plans in
             self.plansCount = count
             self.decidedPlanData = plans
             self.mainView.reload()

--- a/CoNet/Main/Plan/PlanList/DecidedPlan/DecidedPlanListViewController.swift
+++ b/CoNet/Main/Plan/PlanList/DecidedPlan/DecidedPlanListViewController.swift
@@ -31,11 +31,10 @@ class DecidedPlanListViewController: UIViewController {
     // 내 약속만 보기 필터 버튼
     let filterButton = UIButton().then {
         $0.setTitle("내 약속만 보기", for: .normal)
-        $0.setTitleColor(UIColor.textDisabled, for: .normal)
-        $0.titleLabel?.font = UIFont.body3Medium
+        $0.setTitleColor(UIColor.gray500, for: .normal)
+        $0.titleLabel?.font = UIFont.body2Medium
         $0.setImage(UIImage(named: "uncheck-circle"), for: .normal)
         $0.imageEdgeInsets = UIEdgeInsets(top: 0, left: -5, bottom: 0, right: 5)
-        $0.titleEdgeInsets = UIEdgeInsets(top: 0, left: 5, bottom: 0, right: -5)
     }
     
     // tab 선택 indicator
@@ -170,7 +169,7 @@ extension DecidedPlanListViewController {
         upcomingButton.snp.makeConstraints { make in
             make.width.equalTo(61)
             make.top.equalTo(safeArea.snp.top).offset(29)
-            make.leading.equalTo(safeArea.snp.leading).offset(34)
+            make.leading.equalTo(safeArea.snp.leading).offset(25)
         }
         
         pastButton.snp.makeConstraints { make in
@@ -180,7 +179,7 @@ extension DecidedPlanListViewController {
         }
         
         filterButton.snp.makeConstraints { make in
-            make.trailing.equalTo(safeArea.snp.trailing).offset(-35)
+            make.trailing.equalTo(safeArea.snp.trailing).offset(-25)
             make.centerY.equalTo(upcomingButton.snp.centerY)
         }
     }
@@ -194,7 +193,7 @@ extension DecidedPlanListViewController {
     }
     
     func setupselectedTabIndicator() {
-        let buttonWidth = upcomingButton.intrinsicContentSize.width
+//        let buttonWidth = upcomingButton.intrinsicContentSize.width
         updateUnderlinePosition(index: 0)
     }
     
@@ -216,7 +215,7 @@ extension DecidedPlanListViewController {
     private func updateUnderlinePosition(index: Int) {
         let selectedButton = index == 0 ? upcomingButton : pastButton
         let buttonWidth = selectedButton.intrinsicContentSize.width
-        let buttonXPosition = selectedButton.frame.origin.x
+//        let buttonXPosition = selectedButton.frame.origin.x
 
         selectedTabIndicator.snp.remakeConstraints { make in
             make.width.equalTo(buttonWidth)

--- a/CoNet/Main/Plan/PlanList/DecidedPlan/DecidedPlanListViewController.swift
+++ b/CoNet/Main/Plan/PlanList/DecidedPlan/DecidedPlanListViewController.swift
@@ -5,10 +5,43 @@
 //  Created by 이안진 on 2023/07/23.
 //
 
+import SnapKit
+import Then
 import UIKit
 
 class DecidedPlanListViewController: UIViewController {
     var meetingId: Int = 0
+    
+    let upcomingButton = UIButton().then {
+        $0.setTitle("다가오는", for: .normal)
+        $0.setTitleColor(UIColor.textDisabled, for: .normal)
+        $0.setTitleColor(UIColor.black, for: .selected)
+        $0.titleLabel?.font = UIFont.headline3Bold
+        $0.titleLabel?.adjustsFontSizeToFitWidth = true
+    }
+    
+    let pastButton = UIButton().then {
+        $0.setTitle("지난", for: .normal)
+        $0.setTitleColor(UIColor.textDisabled, for: .normal)
+        $0.setTitleColor(UIColor.black, for: .selected)
+        $0.titleLabel?.font = UIFont.headline3Bold
+        $0.titleLabel?.adjustsFontSizeToFitWidth = true
+    }
+
+    // 내 약속만 보기 필터 버튼
+    let filterButton = UIButton().then {
+        $0.setTitle("내 약속만 보기", for: .normal)
+        $0.setTitleColor(UIColor.textDisabled, for: .normal)
+        $0.titleLabel?.font = UIFont.body3Medium
+        $0.setImage(UIImage(named: "uncheck-circle"), for: .normal)
+        $0.imageEdgeInsets = UIEdgeInsets(top: 0, left: -5, bottom: 0, right: 5)
+        $0.titleEdgeInsets = UIEdgeInsets(top: 0, left: 5, bottom: 0, right: -5)
+    }
+    
+    // tab 선택 indicator
+    let selectedTabIndicator = UIView().then {
+        $0.backgroundColor = UIColor.purpleMain
+    }
     
     private lazy var mainView = PlanListCollectionView.init(frame: self.view.frame)
     var plansCount: Int = 0
@@ -29,7 +62,36 @@ class DecidedPlanListViewController: UIViewController {
         view = mainView
         view.backgroundColor = UIColor.gray50
         
+        addView()
+        buttonClicks()
+        layoutConstriants()
         setupCollectionView()
+        setupselectedTabIndicator()
+        
+        // 초기 tab 설정
+        selectTab(index: 0)
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        
+        let selectedIndex = upcomingButton.isSelected ? 0 : 1
+        updateUnderlinePosition(index: selectedIndex)
+    }
+    
+    func buttonClicks() {
+        upcomingButton.addTarget(self, action: #selector(upcomingTapped), for: .touchUpInside)
+        pastButton.addTarget(self, action: #selector(pastTapped), for: .touchUpInside)
+        filterButton.addTarget(self, action: #selector(filterButtonTapped), for: .touchUpInside)
+    }
+
+    @objc private func filterButtonTapped(_ sender: UIButton) {
+        sender.isSelected.toggle()
+
+        let imageName = sender.isSelected ? "check-circle" : "uncheck-circle"
+        sender.setImage(UIImage(named: imageName), for: .normal)
+        
+        mainView.collectionView.reloadData()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -91,5 +153,76 @@ extension DecidedPlanListViewController: UICollectionViewDelegate, UICollectionV
     // 셀 사이의 위아래 간격
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
         return 10
+    }
+}
+
+extension DecidedPlanListViewController {
+    func addView() {
+        self.view.addSubview(upcomingButton)
+        self.view.addSubview(pastButton)
+        self.view.addSubview(selectedTabIndicator)
+        self.view.addSubview(filterButton)
+    }
+    
+    func layoutConstriants() {
+        let safeArea = view.safeAreaLayoutGuide
+        
+        upcomingButton.snp.makeConstraints { make in
+            make.width.equalTo(61)
+            make.top.equalTo(safeArea.snp.top).offset(29)
+            make.leading.equalTo(safeArea.snp.leading).offset(34)
+        }
+        
+        pastButton.snp.makeConstraints { make in
+            make.width.equalTo(31)
+            make.centerY.equalTo(upcomingButton.snp.centerY)
+            make.leading.equalTo(upcomingButton.snp.trailing).offset(16)
+        }
+        
+        filterButton.snp.makeConstraints { make in
+            make.trailing.equalTo(safeArea.snp.trailing).offset(-35)
+            make.centerY.equalTo(upcomingButton.snp.centerY)
+        }
+    }
+    
+    @objc private func upcomingTapped() {
+        selectTab(index: 0)
+    }
+
+    @objc private func pastTapped() {
+        selectTab(index: 1)
+    }
+    
+    func setupselectedTabIndicator() {
+        let buttonWidth = upcomingButton.intrinsicContentSize.width
+        updateUnderlinePosition(index: 0)
+    }
+    
+    private func selectTab(index: Int) {
+        // 버튼 상태 업데이트
+        upcomingButton.isSelected = index == 0
+        pastButton.isSelected = index == 1
+
+        // 선택된 버튼의 글자 색상은 검은색, 나머지는 비활성화 색상
+        let selectedButton = upcomingButton.isSelected ? upcomingButton : pastButton
+        let otherButton = upcomingButton.isSelected ? pastButton : upcomingButton
+
+        selectedButton.setTitleColor(UIColor.black, for: .normal)
+        otherButton.setTitleColor(UIColor.textDisabled, for: .normal)
+
+        updateUnderlinePosition(index: index)
+    }
+
+    private func updateUnderlinePosition(index: Int) {
+        let selectedButton = index == 0 ? upcomingButton : pastButton
+        let buttonWidth = selectedButton.intrinsicContentSize.width
+        let buttonXPosition = selectedButton.frame.origin.x
+
+        selectedTabIndicator.snp.remakeConstraints { make in
+            make.width.equalTo(buttonWidth)
+            make.height.equalTo(2)
+            make.top.equalTo(selectedButton.snp.bottom).offset(2)
+            make.centerX.equalTo(selectedButton.snp.centerX)
+        }
     }
 }

--- a/CoNet/Main/Plan/PlanList/DecidedPlan/DecidedPlanListViewController.swift
+++ b/CoNet/Main/Plan/PlanList/DecidedPlan/DecidedPlanListViewController.swift
@@ -58,7 +58,6 @@ class DecidedPlanListViewController: UIViewController {
         self.navigationController?.navigationBar.isHidden = false
         navigationItem.title = "확정된 약속"
         
-        view = mainView
         view.backgroundColor = UIColor.gray50
         
         addView()
@@ -164,10 +163,11 @@ extension DecidedPlanListViewController: UICollectionViewDelegate, UICollectionV
 
 extension DecidedPlanListViewController {
     func addView() {
-        self.view.addSubview(upcomingButton)
-        self.view.addSubview(pastButton)
-        self.view.addSubview(selectedTabIndicator)
-        self.view.addSubview(filterButton)
+        view.addSubview(upcomingButton)
+        view.addSubview(pastButton)
+        view.addSubview(selectedTabIndicator)
+        view.addSubview(filterButton)
+        view.addSubview(mainView)
     }
     
     func layoutConstriants() {
@@ -189,14 +189,21 @@ extension DecidedPlanListViewController {
             make.trailing.equalTo(safeArea.snp.trailing).offset(-25)
             make.centerY.equalTo(upcomingButton.snp.centerY)
         }
+        
+        mainView.snp.makeConstraints { make in
+            make.top.equalTo(upcomingButton.snp.bottom).offset(24)
+            make.leading.trailing.bottom.equalToSuperview()
+        }
     }
     
     @objc private func upcomingTapped() {
         selectTab(index: 0)
+        getDecidedPlan()
     }
 
     @objc private func pastTapped() {
         selectTab(index: 1)
+        getDecidedPlan()
     }
     
     func setupselectedTabIndicator() {

--- a/CoNet/Main/Plan/PlanList/DecidedPlan/DecidedPlanListViewController.swift
+++ b/CoNet/Main/Plan/PlanList/DecidedPlan/DecidedPlanListViewController.swift
@@ -105,13 +105,20 @@ class DecidedPlanListViewController: UIViewController {
         mainView.collectionView.register(DecidedPlanCell.self, forCellWithReuseIdentifier: DecidedPlanCell.registerId)
     }
     
-    // 확정된 약속 데이터 가져오기
+    // 확정된 다가오는/지난 약속 데이터 가져오기
     private func getDecidedPlan() {
-//        PlanAPI().getDecidedPlansAtMeeting(meetingId: meetingId, period: <#T##String#>) { count, plans in
-//            self.plansCount = count
-//            self.decidedPlanData = plans
-//            self.mainView.reload()
-//        }
+        var period: String = ""
+        if upcomingButton.isSelected {
+            period = "oncoming"
+        } else if pastButton.isSelected {
+            period = "past"
+        }
+        
+        PlanAPI().getDecidedPlansAtMeeting(meetingId: meetingId, period: period) { count, plans in
+            self.plansCount = count
+            self.decidedPlanData = plans
+            self.mainView.reload()
+        }
     }
 }
 

--- a/CoNet/Main/Plan/PlanList/DecidedPlan/DecidedPlanListViewController.swift
+++ b/CoNet/Main/Plan/PlanList/DecidedPlan/DecidedPlanListViewController.swift
@@ -46,11 +46,11 @@ class DecidedPlanListViewController: UIViewController {
     
     // 확정된 약속 데이터 가져오기
     private func getDecidedPlan() {
-        PlanAPI().getDecidedPlansAtMeeting(meetingId: meetingId) { count, plans in
-            self.plansCount = count
-            self.decidedPlanData = plans
-            self.mainView.reload()
-        }
+//        PlanAPI().getDecidedPlansAtMeeting(meetingId: meetingId, period: <#T##String#>) { count, plans in
+//            self.plansCount = count
+//            self.decidedPlanData = plans
+//            self.mainView.reload()
+//        }
     }
 }
 


### PR DESCRIPTION
<!-- PR 제목은
      [PR] 어떤 내용입니다!
      로 해주세요~!! -->

## PR Type ⚙️
<!-- 어떤 변경사항이 있는지 PR에 해당하는 작업들을 체크 후 남겨줍니다.
      사용하지 않는 리스트는 삭제해주세요! -->
- [x] 확정 약속 수정
- [x] [사이드바] 지난/다가오는 약속 api 변경사항 적용 및 연결 
- [x] [사이드바] 지난/다가오는 약속 - 내 약속만 보기 
- [x] plan cell 위치 아래로 내리기 

<br>


## What is this PR? 📝

### Related Issue Number
<!-- 연관된 이슈 번호를 모두 작성해 주세요. ex, #23, #24 -->
- #91 
- #102 
<br>

### Changes
<!-- PR의 작업 내용에 대한 설명을 적습니다. - 추가/변경사항에 대해 작성해주세요. -->
- 이런 점들이 변경되었어요!
<br>

### ScreenShots
<!--
뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
적절한 사이즈로 첨부하는 코드 👇
<img width="300" alt="" src="이미지URL">
-->
확정 약속 수정 

https://github.com/KUIT-CoNet/CoNet-iOS/assets/101566590/2f2729c7-5b9a-44e0-a28f-1538caf4b02d

[사이드바] 지난/다가오는 약속 리스트 & 내 약속만 보기

https://github.com/KUIT-CoNet/CoNet-iOS/assets/101566590/9de7a324-f597-4533-9bd3-c8a01e32c298


<br>


## Other information 🔥
<!-- 기타 참고사항이 있다면 작성해줍니다. -->
- 리뷰하면서 이런 점들을 참고해주세요!
- 확정 약속 수정은 정상 동작하지만, 수정 완료가 되었을 때 화면이 업데이트 되지 않는 문제가 있습니다 . 이건 기능 이슈로 따로 뺄게요! 
<br>



